### PR TITLE
Update to mq-golang v5.0.0 for Go Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ go test -run TestSampleSendReceiveWithErrorHandling
 The IBM MQ client on which this library depends is supported on Linux and Windows, and is [now available for development use on MacOS](https://developer.ibm.com/messaging/2019/02/05/ibm-mq-macos-toolkit-for-developers/)).
 
 1. Install Golang
-    - This library has been validated with Golang v1.11.4 and v1.12.9. If you don't have Golang installed on your system you can [download it here](https://golang.org/doc/install) for MacOS, Linux or Windows
+    - This library has been validated with Golang v1.13.11. If you don't have Golang installed on your system you can [download it here](https://golang.org/doc/install) for MacOS, Linux or Windows
 
 3. Install the MQ Client library
     - If you have a full MQ server with a queue manager installed on your machine then you already have the client library

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/ibm-messaging/mq-golang-jms20
 
-go 1.11
+go 1.13
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/ibm-messaging/mq-golang v1.0.1-0.20190820103725-19b946c185a8
+	github.com/ibm-messaging/mq-golang/v5 v5.0.0
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ibm-messaging/mq-golang v1.0.1-0.20190820103725-19b946c185a8 h1:kUwSXeftVen12FRnShG+Ykhb2Kd6Cd/DbpWwbYal7j0=
 github.com/ibm-messaging/mq-golang v1.0.1-0.20190820103725-19b946c185a8/go.mod h1:qjsZDb7m1oKnbPeDma2JVJTKgyCA91I4bcJ1qHY+gcA=
+github.com/ibm-messaging/mq-golang/v5 v5.0.0 h1:9J8bsDoCo60rbSgB7ZAURPG3L5Kpr+F8dYNOwQ7Qnnk=
+github.com/ibm-messaging/mq-golang/v5 v5.0.0/go.mod h1:ywCwmYbJOU/E0rl+z4GiNoxVMty68O+LVO39a1VMXrE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/mqjms/ConnectionFactoryImpl.go
+++ b/mqjms/ConnectionFactoryImpl.go
@@ -11,7 +11,7 @@ package mqjms
 
 import (
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
-	"github.com/ibm-messaging/mq-golang/ibmmq"
+	ibmmq "github.com/ibm-messaging/mq-golang/v5/ibmmq"
 	"strconv"
 )
 

--- a/mqjms/ConsumerImpl.go
+++ b/mqjms/ConsumerImpl.go
@@ -12,7 +12,7 @@ package mqjms
 import (
 	"errors"
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
-	"github.com/ibm-messaging/mq-golang/ibmmq"
+	ibmmq "github.com/ibm-messaging/mq-golang/v5/ibmmq"
 	"strconv"
 	"strings"
 )

--- a/mqjms/ContextImpl.go
+++ b/mqjms/ContextImpl.go
@@ -11,7 +11,7 @@ package mqjms
 
 import (
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
-	"github.com/ibm-messaging/mq-golang/ibmmq"
+	ibmmq "github.com/ibm-messaging/mq-golang/v5/ibmmq"
 	"strconv"
 )
 

--- a/mqjms/ProducerImpl.go
+++ b/mqjms/ProducerImpl.go
@@ -12,7 +12,7 @@ package mqjms
 import (
 	"fmt"
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
-	"github.com/ibm-messaging/mq-golang/ibmmq"
+	ibmmq "github.com/ibm-messaging/mq-golang/v5/ibmmq"
 	"log"
 	"strconv"
 )

--- a/mqjms/TextMessageImpl.go
+++ b/mqjms/TextMessageImpl.go
@@ -13,7 +13,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
-	"github.com/ibm-messaging/mq-golang/ibmmq"
+	ibmmq "github.com/ibm-messaging/mq-golang/v5/ibmmq"
 	"log"
 	"strconv"
 	"strings"

--- a/tls_connections_test.go
+++ b/tls_connections_test.go
@@ -48,7 +48,8 @@ func TestAnonymousTLSConnection(t *testing.T) {
 		defer context.Close()
 	}
 
-	if errCtx != nil && errCtx.GetReason() == "MQRC_UNKNOWN_CHANNEL_NAME" {
+	if errCtx != nil && (errCtx.GetReason() == "MQRC_UNKNOWN_CHANNEL_NAME" ||
+		errCtx.GetReason() == "MQRC_CHANNEL_CONFIG_ERROR") {
 		// See ./tls-samples/README.md for details on how to configure the required channel.
 		fmt.Println("Skipping TestAnonymousTLSConnection as required channel is not defined.")
 		return
@@ -92,7 +93,8 @@ func TestMutualTLSConnection(t *testing.T) {
 		defer context.Close()
 	}
 
-	if errCtx != nil && errCtx.GetReason() == "MQRC_UNKNOWN_CHANNEL_NAME" {
+	if errCtx != nil && (errCtx.GetReason() == "MQRC_UNKNOWN_CHANNEL_NAME" ||
+		errCtx.GetReason() == "MQRC_CHANNEL_CONFIG_ERROR") {
 		// See ./tls-samples/README.md for details on how to configure the required channel.
 		fmt.Println("Skipping TestMutualTLSConnection as required channel is not defined.")
 		return


### PR DESCRIPTION
Note that mq-golang v5.0.0 also pre-reqs Golang v1.13