### PR TITLE
Update bindings test queue name

### DIFF
--- a/local_bindings_test.go
+++ b/local_bindings_test.go
@@ -11,10 +11,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
+	"github.com/stretchr/testify/assert"
 )
 
 /*
@@ -22,7 +23,13 @@ import (
  * opposed to a remote client connection.
  *
  * Assumes a locally running queue manager called QM1, with a defined local
- * queue called LOCAL.QUEUE
+ * queue called DEV.QUEUE.1
+ *
+ * Note: if you wish to prove that conclusively that the connection is being
+ * made using bindings then one approach is to create a unique queue name such
+ * as MY.LOCAL.QUEUE that exists only on the local queue manager, and update the
+ * string name below to match - so that it cannot be confused with any other
+ * queue manager that you might be able to connect to as a client.
  */
 func TestLocalBindingsConnect(t *testing.T) {
 
@@ -51,7 +58,7 @@ func TestLocalBindingsConnect(t *testing.T) {
 	assert.NotNil(t, context)
 
 	// Equivalent to a JNDI lookup or other declarative definition
-	queue := context.CreateQueue("LOCAL.QUEUE")
+	queue := context.CreateQueue("DEV.QUEUE.1")
 
 	// Set up the consumer ready to receive messages.
 	consumer, conErr := context.CreateConsumer(queue)


### PR DESCRIPTION
Switch to the normal DEV.QUEUE.1 queue name for the local bindings testcase following comment at https://github.com/ibm-messaging/mq-golang-jms20/commit/d2e9d67d1e3f0b2ebe6884696c6dbe99596d3c9c#commitcomment-45268435 where using a different queue name caused confusion.

The original intent was to ensure that the specific queue (LOCAL.QUEUE) could only exist on the local queue manager, and so prove that we're not accidentally connecting using client connect, but it doesn't warrant the potential for confusion of new users, so updating here to use a queue that is typically created by default - and have added a comment in the source file to describe why users may want to make that update themselves.