### PR TITLE
Updates to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,15 +186,15 @@ go build
 ### Verify the installation by executing the tests
 This project includes a series of tests that validate the successful operation of the Golang JMS style client library.
 
-The test cases use the `CreateConnectionFactoryFromDefaultJSONFiles` method to obtain details of a queue manager to connect to from two JSON files in your `/Downloads` directory;
+The test cases use the `CreateConnectionFactoryFromDefaultJSONFiles` method to obtain details of a queue manager to connect to from two JSON files in your `$HOME/Downloads` directory;
 - `connection_info.json` contains information like the hostname/port/channel
   - If you are using the MQ on Cloud service you can download a pre-populated file directly from the queue manager details page as [described here](https://cloud.ibm.com/docs/mqcloud?topic=mqcloud-mqoc_jms_tls#connection_info-json)
-  - Otherwise you can insert details of your own queue manager into [this sample file](./config-samples/connection_info.json) and copy it to your `/Downloads` directory
+  - Otherwise you can insert details of your own queue manager into [this sample file](./config-samples/connection_info.json) and copy it to your `$HOME/Downloads` directory
 - `applicationApiKey.json` contains the Application username and password that will be used to connect to your queue manager
   - If you are using the MQ on Cloud service you can download a pre-populated file directly from the Application Permissions tab in the service console as [described here](https://cloud.ibm.com/docs/mqcloud?topic=mqcloud-mqoc_jms_tls#apikey-json)
-  - Otherwise you can insert details of your own queue manager into [this sample file](./config-samples/applicationApiKey.json) and copy it to your `/Downloads` directory
+  - Otherwise you can insert details of your own queue manager into [this sample file](./config-samples/applicationApiKey.json) and copy it to your `$HOME/Downloads` directory
 
-Once you have added the details of your queue manager and user credentials into the two JSON files and placed them in your `/Downloads` directory you are ready to run the test, which is done in the same way as any other Go tests.
+Once you have added the details of your queue manager and user credentials into the two JSON files and placed them in your `$HOME/Downloads` directory you are ready to run the test, which is done in the same way as any other Go tests.
 
 Note that the tests require the queues `DEV.QUEUE.1` and `DEV.QUEUE.2` to be defined on your queue manager, be empty of messages and be accessible to the application username you are using. This will be the case by default for queue managers provisioned through the MQ on Cloud service, but may require manual configuration for queue managers you have created through other means.
 ```bash

--- a/bytesmessage_test.go
+++ b/bytesmessage_test.go
@@ -22,7 +22,7 @@ import (
  */
 func TestBytesMessageBody(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -53,7 +53,7 @@ func TestBytesMessageBody(t *testing.T) {
  */
 func TestBytesMessageNilBody(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -99,7 +99,7 @@ func TestBytesMessageNilBody(t *testing.T) {
  */
 func TestBytesMessageWithBody(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -148,7 +148,7 @@ func TestBytesMessageWithBody(t *testing.T) {
  */
 func TestBytesMessageInitWithBytes(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -196,7 +196,7 @@ func TestBytesMessageInitWithBytes(t *testing.T) {
  */
 func TestBytesMessageProducerSendBytes(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -241,7 +241,7 @@ func TestBytesMessageProducerSendBytes(t *testing.T) {
  */
 func TestBytesMessageConsumerReceiveBytesBodyNoWait(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -284,7 +284,7 @@ func TestBytesMessageConsumerReceiveBytesBodyNoWait(t *testing.T) {
  */
 func TestBytesMessageConsumerReceiveBytesBody(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -328,7 +328,7 @@ func TestBytesMessageConsumerReceiveBytesBody(t *testing.T) {
  */
 func TestBytesMessageConsumerMixedMessageErrors(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 

--- a/cascade_close_test.go
+++ b/cascade_close_test.go
@@ -26,7 +26,7 @@ import (
  */
 func TestCascadeClose(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 

--- a/connectionfactory_test.go
+++ b/connectionfactory_test.go
@@ -10,11 +10,12 @@
 package main
 
 import (
-	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
+	"github.com/stretchr/testify/assert"
 )
 
 /*
@@ -23,7 +24,7 @@ import (
  */
 func TestLoadCFFromJSON(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, err := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 
 	if err != nil {

--- a/deliverymode_test.go
+++ b/deliverymode_test.go
@@ -11,10 +11,11 @@ package main
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
 	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 /*
@@ -22,7 +23,7 @@ import (
  */
 func TestDeliveryMode(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 

--- a/getbycorrelid_test.go
+++ b/getbycorrelid_test.go
@@ -24,7 +24,7 @@ import (
  */
 func TestGetByCorrelID(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -96,7 +96,7 @@ func TestGetByCorrelID(t *testing.T) {
  */
 func TestSelectorParsing(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -163,7 +163,7 @@ func TestSelectorParsing(t *testing.T) {
  */
 func TestCorrelIDParsing(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 

--- a/mqjms/FactoryFactory.go
+++ b/mqjms/FactoryFactory.go
@@ -23,7 +23,7 @@ import (
 //
 // This method reads the following files;
 //   - $HOME/Downloads/connection_info.json   for host/port/channel information
-//   - $HOME/Downloads/apiKey.json            for username/password information
+//   - $HOME/Downloads/applicationApiKey.json for username/password information
 //
 // If your queue manager is hosted on the IBM MQ on Cloud service then you can
 // download these two files directly from the IBM Cloud service console.
@@ -42,7 +42,7 @@ func CreateConnectionFactoryFromDefaultJSONFiles() (cf ConnectionFactoryImpl, er
 // the file as the two parameters. If empty string is provided then the default
 // location and name is assumed as follows;
 //   - $HOME/Downloads/connection_info.json   for host/port/channel information
-//   - $HOME/Downloads/apiKey.json            for username/password information
+//   - $HOME/Downloads/applicationApiKey.json            for username/password information
 //
 // If your queue manager is hosted on the IBM MQ on Cloud service then you can
 // download these two files directly from the IBM Cloud service console.

--- a/receivewithwait_test.go
+++ b/receivewithwait_test.go
@@ -10,10 +10,11 @@
 package main
 
 import (
-	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
+	"github.com/stretchr/testify/assert"
 )
 
 /*
@@ -21,7 +22,7 @@ import (
  */
 func TestReceiveWait(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -80,7 +81,7 @@ func TestReceiveWait(t *testing.T) {
 
 func TestReceiveStringBodyWait(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 

--- a/requestreply_test.go
+++ b/requestreply_test.go
@@ -23,7 +23,7 @@ import (
  */
 func TestRequestReply(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 

--- a/sample_errorhandling_test.go
+++ b/sample_errorhandling_test.go
@@ -10,9 +10,10 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 /*
@@ -47,7 +48,7 @@ func TestFailToConnect(t *testing.T) {
  */
 func TestFailToConnectToQueue(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 

--- a/sample_sendreceive_test.go
+++ b/sample_sendreceive_test.go
@@ -11,9 +11,10 @@ package main
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 /*
@@ -153,7 +154,7 @@ func TestSampleSendReceiveWithLimitedErrorHandling(t *testing.T) {
  */
 func TestReceiveNoWaitWithoutMessage(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	if cfErr != nil {
 		fmt.Println(cfErr)

--- a/textmessage_test.go
+++ b/textmessage_test.go
@@ -10,10 +10,11 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
 	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 /*
@@ -21,7 +22,7 @@ import (
  */
 func TestTextMessageBody(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -46,7 +47,7 @@ func TestTextMessageBody(t *testing.T) {
  */
 func TestTextMessageNilBody(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 
@@ -93,7 +94,7 @@ func TestTextMessageNilBody(t *testing.T) {
  */
 func TestTextMessageEmptyBody(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 

--- a/timestamp_test.go
+++ b/timestamp_test.go
@@ -10,11 +10,12 @@
 package main
 
 import (
+	"testing"
+	"time"
+
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
 	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 /*
@@ -23,7 +24,7 @@ import (
  */
 func TestJMSTimestamp(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 

--- a/timetolive_test.go
+++ b/timetolive_test.go
@@ -10,11 +10,12 @@
 package main
 
 import (
+	"testing"
+	"time"
+
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
 	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 /*
@@ -23,7 +24,7 @@ import (
  */
 func TestMsgTimeToLive(t *testing.T) {
 
-	// Loads CF parameters from connection_info.json and apiKey.json in the Downloads directory
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	assert.Nil(t, cfErr)
 


### PR DESCRIPTION
- clarify what is meant by "your `/Downloads` directory";
- correct references, in comments, to `apiKey.json` because `CreateConnectionFactoryFromJSON` function will be looking for `applicationApiKey.json`.

Hey folks,

New to GoLang and IBM MQ and trying to following along the tut (very good, BTW). Just need a bit of clarification on whether you meant `/Downloads` or `~/Downloads`, then spotted comments had incorrect references to `apiKey.json` when I was digging through the code to find my answer.

In submitting this PR for consideration, I agree to the terms of the CLA.