### PR TITLE
Add support for ApplName on Connection - #20

### DIFF
--- a/config-samples/connection_info.json
+++ b/config-samples/connection_info.json
@@ -2,5 +2,6 @@
  "queueManagerName": "QM1",
  "hostname": "myqm1.myserver.com",
  "listenerPort": 31234,
- "applicationChannelName": "CLOUD.APP.SVRCONN"
+ "applicationChannelName": "CLOUD.APP.SVRCONN",
+ "applicationName": "example"
 }

--- a/mqjms/ConnectionFactoryImpl.go
+++ b/mqjms/ConnectionFactoryImpl.go
@@ -40,6 +40,9 @@ type ConnectionFactoryImpl struct {
 
 	KeyRepository    string
 	CertificateLabel string
+
+	// Allthough only available per MQ 9.1.2 it looks like a good idea to have this present in MQ-JMS
+	ApplName	string
 }
 
 // CreateContext implements the JMS method to create a connection to an IBM MQ
@@ -93,6 +96,9 @@ func (cf ConnectionFactoryImpl) CreateContextWithSessionMode(sessionMode int) (j
 			cno.SSLConfig = sco
 
 		}
+
+		// Fill in the optional (possible since MQ 9.1.2) application name
+		cno.ApplName = cf.ApplName
 
 	} else if cf.TransportType == TransportType_BINDINGS {
 

--- a/mqjms/FactoryFactory.go
+++ b/mqjms/FactoryFactory.go
@@ -23,7 +23,7 @@ import (
 //
 // This method reads the following files;
 //   - $HOME/Downloads/connection_info.json   for host/port/channel information
-//   - $HOME/Downloads/applicationApiKey.json for username/password information
+//   - $HOME/Downloads/apiKey.json            for username/password information
 //
 // If your queue manager is hosted on the IBM MQ on Cloud service then you can
 // download these two files directly from the IBM Cloud service console.
@@ -42,7 +42,7 @@ func CreateConnectionFactoryFromDefaultJSONFiles() (cf ConnectionFactoryImpl, er
 // the file as the two parameters. If empty string is provided then the default
 // location and name is assumed as follows;
 //   - $HOME/Downloads/connection_info.json   for host/port/channel information
-//   - $HOME/Downloads/applicationApiKey.json            for username/password information
+//   - $HOME/Downloads/apiKey.json            for username/password information
 //
 // If your queue manager is hosted on the IBM MQ on Cloud service then you can
 // download these two files directly from the IBM Cloud service console.
@@ -87,7 +87,7 @@ func CreateConnectionFactoryFromJSON(connectionInfoLocn string, apiKeyLocn strin
 		return ConnectionFactoryImpl{}, err
 	}
 
-	var qmName, hostname, appChannel string
+	var qmName, hostname, appChannel, appName string
 	var port int
 
 	qmName, errQM := parseStringValueFromJSON("queueManagerName", connInfoMap, connectionInfoLocn)
@@ -108,6 +108,11 @@ func CreateConnectionFactoryFromJSON(connectionInfoLocn string, apiKeyLocn strin
 	appChannel, errChannel := parseStringValueFromJSON("applicationChannelName", connInfoMap, connectionInfoLocn)
 	if errChannel != nil {
 		return ConnectionFactoryImpl{}, errChannel
+	}
+
+	appName, errAppName := parseStringValueFromJSON("applicationName", connInfoMap, connectionInfoLocn)
+	if errAppName != nil {
+		return ConnectionFactoryImpl{}, errAppName
 	}
 
 	// Now unmarshall and parse out the values from the api key file (that
@@ -140,6 +145,7 @@ func CreateConnectionFactoryFromJSON(connectionInfoLocn string, apiKeyLocn strin
 		ChannelName: appChannel,
 		UserName:    username,
 		Password:    password,
+		ApplName:	 appName,
 	}
 
 	// Give the populated ConnectionFactory back to the caller.


### PR DESCRIPTION
A small feature to include the application name as one of the parameters on a MQ connection.

I accept the terms in the CLA.