### PR TITLE
Applname enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ your own error handling or logging.
 * Send and receive under a local transaction - [local_transaction_test.go](local_transaction_test.go)
 * Sending a message that expires after a period of time - [timetolive_test.go](timetolive_test.go)
 * Handle error codes returned by the queue manager - [sample_errorhandling_test.go](sample_errorhandling_test.go)
+* Set the application name (ApplName) on connections - [applname_test.go](applname_test.go)
+
 
 As normal with Go, you can run any individual testcase by executing a command such as;
 ```bash

--- a/applname_test.go
+++ b/applname_test.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) IBM Corporation 2019
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package main
+
+import (
+	"testing"
+
+	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
+	"github.com/stretchr/testify/assert"
+)
+
+/*
+ * Test send and receive of a text message with no content.
+ */
+func TestApplName(t *testing.T) {
+
+	// Pick an application name for testing
+	applName := "MyApplicationName"
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Set the appl name
+	cf.ApplName = applName
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// Create a TextMessage, and check it has nil content.
+	msg := context.CreateTextMessage()
+	assert.Nil(t, msg.GetText())
+
+	// Now send the message and get it back again, to check that it roundtripped.
+	queue := context.CreateQueue("DEV.QUEUE.1")
+	errSend := context.CreateProducer().SetTimeToLive(60000).Send(queue, msg)
+	assert.Nil(t, errSend)
+
+	consumer, errCons := context.CreateConsumer(queue)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+	assert.Nil(t, errCons)
+
+	rcvMsg, errRvc := consumer.ReceiveNoWait()
+	assert.Nil(t, errRvc)
+	assert.NotNil(t, rcvMsg)
+
+	messageImpl, ok := rcvMsg.(*mqjms.TextMessageImpl)
+	assert.True(t, ok)
+
+	// Check that the application name was successfully stored in the message
+	// that we sent.
+	assert.Equal(t, applName, messageImpl.GetApplName())
+
+}

--- a/mqjms/ConnectionFactoryImpl.go
+++ b/mqjms/ConnectionFactoryImpl.go
@@ -42,7 +42,7 @@ type ConnectionFactoryImpl struct {
 	CertificateLabel string
 
 	// Allthough only available per MQ 9.1.2 it looks like a good idea to have this present in MQ-JMS
-	ApplName	string
+	ApplName string
 }
 
 // CreateContext implements the JMS method to create a connection to an IBM MQ

--- a/mqjms/FactoryFactory.go
+++ b/mqjms/FactoryFactory.go
@@ -23,7 +23,7 @@ import (
 //
 // This method reads the following files;
 //   - $HOME/Downloads/connection_info.json   for host/port/channel information
-//   - $HOME/Downloads/apiKey.json            for username/password information
+//   - $HOME/Downloads/applicationApiKey.json for username/password information
 //
 // If your queue manager is hosted on the IBM MQ on Cloud service then you can
 // download these two files directly from the IBM Cloud service console.
@@ -42,7 +42,7 @@ func CreateConnectionFactoryFromDefaultJSONFiles() (cf ConnectionFactoryImpl, er
 // the file as the two parameters. If empty string is provided then the default
 // location and name is assumed as follows;
 //   - $HOME/Downloads/connection_info.json   for host/port/channel information
-//   - $HOME/Downloads/apiKey.json            for username/password information
+//   - $HOME/Downloads/applicationApiKey.json for username/password information
 //
 // If your queue manager is hosted on the IBM MQ on Cloud service then you can
 // download these two files directly from the IBM Cloud service console.
@@ -110,10 +110,8 @@ func CreateConnectionFactoryFromJSON(connectionInfoLocn string, apiKeyLocn strin
 		return ConnectionFactoryImpl{}, errChannel
 	}
 
-	appName, errAppName := parseStringValueFromJSON("applicationName", connInfoMap, connectionInfoLocn)
-	if errAppName != nil {
-		return ConnectionFactoryImpl{}, errAppName
-	}
+	// app name is an optional field so we silently ignore if it is not present
+	appName, _ = parseStringValueFromJSON("applicationName", connInfoMap, connectionInfoLocn)
 
 	// Now unmarshall and parse out the values from the api key file (that
 	// contains the username/password credentials).
@@ -145,7 +143,7 @@ func CreateConnectionFactoryFromJSON(connectionInfoLocn string, apiKeyLocn strin
 		ChannelName: appChannel,
 		UserName:    username,
 		Password:    password,
-		ApplName:	 appName,
+		ApplName:    appName,
 	}
 
 	// Give the populated ConnectionFactory back to the caller.

--- a/mqjms/MessageImpl.go
+++ b/mqjms/MessageImpl.go
@@ -258,3 +258,19 @@ func (msg *MessageImpl) GetJMSTimestamp() int64 {
 
 	return timestamp
 }
+
+// GetApplName retrieves the PutApplName field from the MQMD.
+// This method is not exposed on the JMS style interface and is mainly for testing purposes.
+func (msg MessageImpl) GetApplName() string {
+	applName := ""
+
+	// Note that if there is no MQMD then there is no correlID stored.
+	if msg.mqmd != nil {
+
+		// Get hold of the bytes representation of the correlation ID.
+		applName = msg.mqmd.PutApplName
+
+	}
+
+	return applName
+}

--- a/next-features.txt
+++ b/next-features.txt
@@ -14,7 +14,6 @@ Not currently implemented:
 
 Client capabilities for participating in Uniform Clusters;
 - CCDT to allow listing queue managers
-- Set APPLTag to name the logical application
 - Auto reconnect (any) + MQCNO_RECONNECT_QMGR 
 
 Known issues:


### PR DESCRIPTION
Changes as described in https://github.com/ibm-messaging/mq-golang-jms20/pull/23#pullrequestreview-565169883

- Making the applicationName attribute in the connection_info.json optional so that it doesn't break existing scenarios
- Change back the comments at line 26 and 45 of FactoryFactory.go, which look to have accidentally overwritten another change that was delivered while this one was being worked
- Add a testcase to prove that the ApplName attribute is being set into the message correctly (I verified visually that it is, but the test case prevents regressions in the future)

Also formatting with "go fmt" and a couple of small docs updates to highlight the new support.