### PR TITLE
Support for asynchronous put

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ your own error handling or logging.
 * Handle error codes returned by the queue manager - [sample_errorhandling_test.go](sample_errorhandling_test.go)
 * Set the application name (ApplName) on connections - [applname_test.go](applname_test.go)
 * Receive messages over 32kb in size by setting the receive buffer size - [largemessage_test.go](largemessage_test.go)
+* Asynchronous put - [asyncput_test.go](asyncput_test.go)
 
 As normal with Go, you can run any individual testcase by executing a command such as;
 ```bash

--- a/asyncput_test.go
+++ b/asyncput_test.go
@@ -59,7 +59,7 @@ func TestAsyncPutSample(t *testing.T) {
 }
 
 /*
- * Compare the performance benefit of sending messages non-persistent, non-transational
+ * Compare the performance benefit of sending messages non-persistent, non-transactional
  * messages asynchronously - which can give a higher message rate, in exchange for
  * less/no checking for errors.
  *
@@ -298,7 +298,7 @@ func TestAsyncPutCheckCountWithFailure(t *testing.T) {
 		// the next check which takes place at 30.
 		if i == 0 && errSend != nil && errSend.GetReason() == "MQRC_UNKNOWN_OBJECT_NAME" {
 
-			fmt.Println("Skipping TestAsyncPutCheckCountWithFailure as " + QUEUE_25_NAME + " is not defined.")
+			fmt.Println("Skipping TestAsyncPutCheckCountWithFailure as queue " + QUEUE_25_NAME + " is not defined.")
 			queueExists = false
 			break // Stop the loop at this point as we know it won't change.
 
@@ -401,4 +401,345 @@ func TestAsyncPutGetterSetter(t *testing.T) {
 	queue = queue.SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_AS_DEST)
 	assert.Equal(t, jms20subset.Destination_PUT_ASYNC_ALLOWED_AS_DEST, queue.GetPutAsyncAllowed())
 
+}
+
+/*
+ * Compare the performance benefit of sending messages persistent, transactional
+ * messages asynchronously - which can give a higher message rate, in exchange for
+ * less/no checking for errors.
+ *
+ * The test checks that async put is at least 10% faster than synchronous put.
+ * (in testing against a remote queue manager it was actually 30% faster)
+ */
+func TestAsyncPutPersistentTransactedComparison(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Check the default value for SendCheckCount, which means never check for errors.
+	assert.Equal(t, 0, cf.SendCheckCount)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	transactedContext, ctxErr := cf.CreateContextWithSessionMode(jms20subset.JMSContextSESSIONTRANSACTED)
+	assert.Nil(t, ctxErr)
+	if transactedContext != nil {
+		defer transactedContext.Close()
+	}
+
+	// --------------------------------------------------------
+	// Start by sending a set of messages using the normal synchronous approach, in
+	// order that we can get a baseline timing.
+
+	// Set up the producer and consumer with the SYNCHRONOUS (not async yet) queue
+	syncQueue := transactedContext.CreateQueue("DEV.QUEUE.1")
+	producer := transactedContext.CreateProducer().SetDeliveryMode(jms20subset.DeliveryMode_PERSISTENT).SetTimeToLive(60000)
+
+	consumer, errCons := transactedContext.CreateConsumer(syncQueue)
+	assert.Nil(t, errCons)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+
+	// Create a unique message prefix representing this execution of the test case.
+	testcasePrefix := strconv.FormatInt(currentTimeMillis(), 10)
+	syncMsgPrefix := "syncput_" + testcasePrefix + "_"
+	asyncMsgPrefix := "asyncput_" + testcasePrefix + "_"
+	numberMessages := 50
+
+	// First get a baseline for how long it takes us to send the batch of messages
+	// WITHOUT async put (i.e. using normal synchronous put)
+	syncStartTime := currentTimeMillis()
+	for i := 0; i < numberMessages; i++ {
+
+		// Create a TextMessage and send it.
+		msg := transactedContext.CreateTextMessageWithString(syncMsgPrefix + strconv.Itoa(i))
+
+		errSend := producer.Send(syncQueue, msg)
+		assert.Nil(t, errSend)
+	}
+	transactedContext.Commit()
+	syncEndTime := currentTimeMillis()
+
+	syncSendTime := syncEndTime - syncStartTime
+	//fmt.Println("Took " + strconv.FormatInt(syncSendTime, 10) + "ms to send " + strconv.Itoa(numberMessages) + " transacted synchronous messages.")
+
+	// Receive the messages back again to tidy the queue back to a clean state
+	finishedReceiving := false
+	rcvCount := 0
+
+	for !finishedReceiving {
+		rcvTxt, errRvc := consumer.ReceiveStringBodyNoWait()
+		assert.Nil(t, errRvc)
+
+		if rcvTxt != nil {
+			// Check the message bod matches what we expect
+			assert.Equal(t, syncMsgPrefix+strconv.Itoa(rcvCount), *rcvTxt)
+			rcvCount++
+		} else {
+			finishedReceiving = true
+		}
+	}
+	transactedContext.Commit()
+
+	// --------------------------------------------------------
+	// Now repeat the experiment but with ASYNC message put
+	asyncQueue := transactedContext.CreateQueue("DEV.QUEUE.1").SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED)
+
+	asyncStartTime := currentTimeMillis()
+	for i := 0; i < numberMessages; i++ {
+
+		// Create a TextMessage and send it.
+		msg := transactedContext.CreateTextMessageWithString(asyncMsgPrefix + strconv.Itoa(i))
+
+		errSend := producer.Send(asyncQueue, msg)
+		assert.Nil(t, errSend)
+	}
+	transactedContext.Commit()
+	asyncEndTime := currentTimeMillis()
+
+	asyncSendTime := asyncEndTime - asyncStartTime
+	//fmt.Println("Took " + strconv.FormatInt(asyncSendTime, 10) + "ms to send " + strconv.Itoa(numberMessages) + " transacted ASYNC messages.")
+
+	// Receive the messages back again to tidy the queue back to a clean state
+	finishedReceiving = false
+	rcvCount = 0
+
+	for !finishedReceiving {
+		rcvTxt, errRvc := consumer.ReceiveStringBodyNoWait()
+		assert.Nil(t, errRvc)
+
+		if rcvTxt != nil {
+			// Check the message bod matches what we expect
+			assert.Equal(t, asyncMsgPrefix+strconv.Itoa(rcvCount), *rcvTxt)
+			rcvCount++
+		} else {
+			finishedReceiving = true
+		}
+	}
+	transactedContext.Commit()
+
+	assert.Equal(t, numberMessages, rcvCount)
+
+	// Expect that async put is at least 10% faster than sync put for non-persistent messages
+	// (in testing against a remote queue manager it was actually 30% faster)
+	assert.True(t, 100*asyncSendTime < 90*syncSendTime)
+
+}
+
+/*
+ * Validate that errors are reported at the correct interval when a problem occurs during a
+ * transactional put of persistent messages (i.e. when the commit occurs)
+ *
+ * This test case forces a failure to occur by sending 50 messages to a queue that has had its
+ * maximum depth set to 25. In the transacted async put case the Send method always completes
+ * successfully, but the error will be returned on Commit.
+ */
+func TestAsyncPutTransactedCheckCountWithFailure(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// The SendCheckCount is not used for async put under a transacted session.
+	assert.Equal(t, 0, cf.SendCheckCount)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	transactedContext, ctxErr := cf.CreateContextWithSessionMode(jms20subset.JMSContextSESSIONTRANSACTED)
+	assert.Nil(t, ctxErr)
+	if transactedContext != nil {
+		defer transactedContext.Close()
+	}
+
+	// Set up the producer and consumer with the async queue.
+	QUEUE_25_NAME := "DEV.MAXDEPTH25"
+	asyncQueue := transactedContext.CreateQueue(QUEUE_25_NAME).SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED)
+	producer := transactedContext.CreateProducer().SetDeliveryMode(jms20subset.DeliveryMode_PERSISTENT).SetTimeToLive(60000)
+
+	// Create a unique message prefix representing this execution of the test case.
+	testcasePrefix := strconv.FormatInt(currentTimeMillis(), 10)
+	msgPrefix := "checkCount_" + testcasePrefix + "_"
+	numberMessages := 50
+
+	// Variable to track whether the queue exists or not.
+	queueExists := true
+
+	// --------------------------------------------------------
+	// Send ASYNC message put
+	for i := 0; i < numberMessages; i++ {
+
+		// Create a TextMessage and send it.
+		msg := transactedContext.CreateTextMessageWithString(msgPrefix + strconv.Itoa(i))
+
+		errSend2 := producer.Send(asyncQueue, msg)
+
+		// Skip the test if the destination does not exist on this queue manager.
+		if i == 0 && errSend2 != nil && errSend2.GetReason() == "MQRC_UNKNOWN_OBJECT_NAME" {
+
+			fmt.Println("Skipping TestAsyncPutTransactedCheckCountWithFailure as queue " + QUEUE_25_NAME + " is not defined.")
+			queueExists = false
+			break // Stop the loop at this point as we know it won't change.
+
+		}
+
+		// In the Transacted case the response from Send is always Nil, because any errors
+		// will be reflected on the Commit call.
+		assert.Nil(t, errSend2)
+
+		if i%10 == 0 {
+			commitErr := transactedContext.Commit()
+
+			if i == 30 || i == 40 {
+
+				assert.NotNil(t, commitErr)
+				assert.Equal(t, "2003", commitErr.GetErrorCode())
+				assert.Equal(t, "MQRC_BACKED_OUT", commitErr.GetReason())
+
+				// Linked error is out normal async put error with message about "N failures"
+				linkedErr1 := commitErr.GetLinkedError()
+				assert.Equal(t, "AsyncPutFailure", linkedErr1.(jms20subset.JMSExceptionImpl).GetErrorCode())
+				assert.True(t, strings.Contains(linkedErr1.(jms20subset.JMSExceptionImpl).GetReason(), "6 failures"))
+				assert.True(t, strings.Contains(linkedErr1.(jms20subset.JMSExceptionImpl).GetReason(), "0 warnings"))
+
+				// Second level linked message should have reason of MQRC_Q_FULL
+				linkedErr2 := linkedErr1.(jms20subset.JMSExceptionImpl).GetLinkedError()
+				assert.NotNil(t, linkedErr2)
+				linkedReason := linkedErr2.(jms20subset.JMSExceptionImpl).GetReason()
+				assert.Equal(t, "MQRC_Q_FULL", linkedReason)
+
+			} else {
+				// Messages 31, 32, ... 39, 41, 42, ...
+				// do not give an error because we don't make an error check.
+				assert.Nil(t, commitErr)
+			}
+		}
+	}
+
+	// Clear out the transaction context.
+	transactedContext.Commit()
+
+	// If the queue exists then tidy up the messages we sent.
+	if queueExists {
+
+		// ----------------------------------
+		// Receive the messages back again to tidy the queue back to a clean state
+		consumer, errCons := transactedContext.CreateConsumer(asyncQueue)
+		assert.Nil(t, errCons)
+		if consumer != nil {
+			defer consumer.Close()
+		}
+
+		// Receive the messages back again
+		finishedReceiving := false
+
+		for !finishedReceiving {
+			rcvMsg, errRvc := consumer.ReceiveNoWait()
+			assert.Nil(t, errRvc)
+
+			if rcvMsg == nil {
+				finishedReceiving = true
+			}
+		}
+
+		transactedContext.Commit()
+	}
+}
+
+/*
+ * Validate that NO errors are reported when a problem occurs during a
+ * transactional put of a non-persistent message.
+ *
+ * (per https://www.ibm.com/docs/en/ibm-mq/9.1?topic=application-putting-messages-asynchronously-in-mq-classes-jms)
+ *
+ * This test case forces a failure to occur by sending 50 messages to a queue that has had its
+ * maximum depth set to 25.
+ */
+func TestAsyncPutTransactedNonPersistentCheckCountWithFailure(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// The SendCheckCount is not used for async put under a transacted session.
+	assert.Equal(t, 0, cf.SendCheckCount)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	transactedContext, ctxErr := cf.CreateContextWithSessionMode(jms20subset.JMSContextSESSIONTRANSACTED)
+	assert.Nil(t, ctxErr)
+	if transactedContext != nil {
+		defer transactedContext.Close()
+	}
+
+	// Set up the producer and consumer with the async queue.
+	QUEUE_25_NAME := "DEV.MAXDEPTH25"
+	asyncQueue := transactedContext.CreateQueue(QUEUE_25_NAME).SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED)
+	producer := transactedContext.CreateProducer().SetDeliveryMode(jms20subset.DeliveryMode_NON_PERSISTENT).SetTimeToLive(60000)
+
+	// Create a unique message prefix representing this execution of the test case.
+	testcasePrefix := strconv.FormatInt(currentTimeMillis(), 10)
+	msgPrefix := "checkCount_" + testcasePrefix + "_"
+	numberMessages := 50
+
+	// Variable to track whether the queue exists or not.
+	queueExists := true
+
+	// --------------------------------------------------------
+	// Send ASYNC message put
+	for i := 0; i < numberMessages; i++ {
+
+		// Create a TextMessage and send it.
+		msg := transactedContext.CreateTextMessageWithString(msgPrefix + strconv.Itoa(i))
+
+		errSend2 := producer.Send(asyncQueue, msg)
+
+		// Skip the test if the destination does not exist on this queue manager.
+		if i == 0 && errSend2 != nil && errSend2.GetReason() == "MQRC_UNKNOWN_OBJECT_NAME" {
+
+			fmt.Println("Skipping TestAsyncPutTransactedNonPersistentCheckCountWithFailure as queue " + QUEUE_25_NAME + " is not defined.")
+			queueExists = false
+			break // Stop the loop at this point as we know it won't change.
+
+		}
+
+		// In the Transacted case the response from Send is always Nil, because any errors
+		// will be reflected on the Commit call.
+		assert.Nil(t, errSend2)
+
+		if i%10 == 0 {
+			commitErr := transactedContext.Commit()
+
+			// No errors reported for NonPersistent messages in a transaction.
+			assert.Nil(t, commitErr)
+
+		}
+	}
+
+	// If the queue exists then tidy up the messages we sent.
+	if queueExists {
+
+		// ----------------------------------
+		// Receive the messages back again to tidy the queue back to a clean state
+		consumer, errCons := transactedContext.CreateConsumer(asyncQueue)
+		assert.Nil(t, errCons)
+		if consumer != nil {
+			defer consumer.Close()
+		}
+
+		// Receive the messages back again
+		finishedReceiving := false
+
+		for !finishedReceiving {
+			rcvMsg, errRvc := consumer.ReceiveNoWait()
+			assert.Nil(t, errRvc)
+
+			if rcvMsg == nil {
+				finishedReceiving = true
+			}
+		}
+
+		transactedContext.Commit()
+	}
 }

--- a/asyncput_test.go
+++ b/asyncput_test.go
@@ -10,7 +10,9 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
@@ -19,10 +21,10 @@ import (
 )
 
 /*
- * Test the ability to send a message asynchronously, which can give a higher
+ * Minimal example showing how to send a message asynchronously, which can give a higher
  * rate of sending non-persistent messages, in exchange for less/no checking for errors.
  */
-func TestAsyncPut(t *testing.T) {
+func TestAsyncPutSample(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
@@ -35,6 +37,55 @@ func TestAsyncPut(t *testing.T) {
 	if context != nil {
 		defer context.Close()
 	}
+
+	// Set up a Producer for NonPersistent messages and Destination the PutAsyncAllowed=true
+	producer := context.CreateProducer().SetDeliveryMode(jms20subset.DeliveryMode_NON_PERSISTENT)
+	asyncQueue := context.CreateQueue("DEV.QUEUE.1").SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED)
+
+	// Send a message (asynchronously)
+	msg := context.CreateTextMessageWithString("some text")
+	errSend := producer.Send(asyncQueue, msg)
+	assert.Nil(t, errSend)
+
+	// Tidy up the message to leave the test clean.
+	consumer, errCons := context.CreateConsumer(asyncQueue)
+	assert.Nil(t, errCons)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+	_, errRvc := consumer.ReceiveStringBodyNoWait()
+	assert.Nil(t, errRvc)
+
+}
+
+/*
+ * Compare the performance benefit of sending messages non-persistent, non-transational
+ * messages asynchronously - which can give a higher message rate, in exchange for
+ * less/no checking for errors.
+ *
+ * The test checks that async put is at least 10% faster than synchronous put.
+ * (in testing against a remote queue manager it was actually 30% faster)
+ */
+func TestAsyncPutComparison(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Check the default value for SendCheckCount, which means never check for errors.
+	assert.Equal(t, 0, cf.SendCheckCount)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// --------------------------------------------------------
+	// Start by sending a set of messages using the normal synchronous approach, in
+	// order that we can get a baseline timing.
 
 	// Set up the producer and consumer with the SYNCHRONOUS (not async yet) queue
 	syncQueue := context.CreateQueue("DEV.QUEUE.1")
@@ -53,7 +104,7 @@ func TestAsyncPut(t *testing.T) {
 	numberMessages := 50
 
 	// First get a baseline for how long it takes us to send the batch of messages
-	// WITHOUT async put.
+	// WITHOUT async put (i.e. using normal synchronous put)
 	syncStartTime := currentTimeMillis()
 	for i := 0; i < numberMessages; i++ {
 
@@ -68,7 +119,7 @@ func TestAsyncPut(t *testing.T) {
 	syncSendTime := syncEndTime - syncStartTime
 	//fmt.Println("Took " + strconv.FormatInt(syncSendTime, 10) + "ms to send " + strconv.Itoa(numberMessages) + " synchronous messages.")
 
-	// Receive the messages back again
+	// Receive the messages back again to tidy the queue back to a clean state
 	finishedReceiving := false
 	rcvCount := 0
 
@@ -103,7 +154,7 @@ func TestAsyncPut(t *testing.T) {
 	asyncSendTime := asyncEndTime - asyncStartTime
 	//fmt.Println("Took " + strconv.FormatInt(asyncSendTime, 10) + "ms to send " + strconv.Itoa(numberMessages) + " ASYNC messages.")
 
-	// Receive the messages back again
+	// Receive the messages back again to tidy the queue back to a clean state
 	finishedReceiving = false
 	rcvCount = 0
 
@@ -126,6 +177,193 @@ func TestAsyncPut(t *testing.T) {
 	// (in testing against a remote queue manager it was actually 30% faster)
 	assert.True(t, 100*asyncSendTime < 90*syncSendTime)
 
+}
+
+/*
+ * Test the ability to successfully send async messages with checking enabled.
+ *
+ * This test is checking that no failures are reported when the interval checking
+ * is enabled.
+ */
+func TestAsyncPutCheckCount(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Set the CF flag to enable checking for errors after a certain number of messages
+	cf.SendCheckCount = 10
+
+	// Check the default value for SendCheckCount
+	assert.Equal(t, 10, cf.SendCheckCount)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// Set up the producer and consumer with the async queue.
+	asyncQueue := context.CreateQueue("DEV.QUEUE.1").SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED)
+	producer := context.CreateProducer().SetDeliveryMode(jms20subset.DeliveryMode_NON_PERSISTENT)
+
+	// Create a unique message prefix representing this execution of the test case.
+	testcasePrefix := strconv.FormatInt(currentTimeMillis(), 10)
+	msgPrefix := "checkCount_" + testcasePrefix + "_"
+	numberMessages := 50
+
+	// --------------------------------------------------------
+	// Do ASYNC message put
+	for i := 0; i < numberMessages; i++ {
+
+		// Create a TextMessage and send it.
+		msg := context.CreateTextMessageWithString(msgPrefix + strconv.Itoa(i))
+
+		errSend := producer.Send(asyncQueue, msg)
+		assert.Nil(t, errSend)
+	}
+
+	// ----------------------------------
+	// Receive the messages back again to tidy the queue back to a clean state
+	consumer, errCons := context.CreateConsumer(asyncQueue)
+	assert.Nil(t, errCons)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+
+	finishedReceiving := false
+
+	for !finishedReceiving {
+		rcvMsg, errRvc := consumer.ReceiveNoWait()
+		assert.Nil(t, errRvc)
+
+		if rcvMsg == nil {
+			finishedReceiving = true
+		}
+	}
+}
+
+/*
+ * Validate that errors are reported at the correct interval when a problem occurs.
+ *
+ * This test case forces a failure to occur by sending 50 messages to a queue that has had its
+ * maximum depth set to 25. With SendCheckCount of 10 we will not receive an error until message 30,
+ * which is the first time the error check is made after the point at which the queue has filled up.
+ */
+func TestAsyncPutCheckCountWithFailure(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Set the CF flag to enable checking for errors after a certain number of messages
+	cf.SendCheckCount = 10
+
+	// Check the value for SendCheckCount was stored correctly.
+	assert.Equal(t, 10, cf.SendCheckCount)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// Set up the producer and consumer with the async queue.
+	QUEUE_25_NAME := "DEV.MAXDEPTH25"
+	asyncQueue := context.CreateQueue(QUEUE_25_NAME).SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED)
+	producer := context.CreateProducer().SetDeliveryMode(jms20subset.DeliveryMode_NON_PERSISTENT)
+
+	// Create a unique message prefix representing this execution of the test case.
+	testcasePrefix := strconv.FormatInt(currentTimeMillis(), 10)
+	msgPrefix := "checkCount_" + testcasePrefix + "_"
+	numberMessages := 50
+
+	// Variable to track whether the queue exists or not.
+	queueExists := true
+
+	// --------------------------------------------------------
+	// Send ASYNC message put
+	for i := 0; i < numberMessages; i++ {
+
+		// Create a TextMessage and send it.
+		msg := context.CreateTextMessageWithString(msgPrefix + strconv.Itoa(i))
+
+		errSend := producer.Send(asyncQueue, msg)
+
+		// Messages will start to fail at number 25 but we don't get an error until
+		// the next check which takes place at 30.
+		if i == 0 && errSend != nil && errSend.GetReason() == "MQRC_UNKNOWN_OBJECT_NAME" {
+
+			fmt.Println("Skipping TestAsyncPutCheckCountWithFailure as " + QUEUE_25_NAME + " is not defined.")
+			queueExists = false
+			break // Stop the loop at this point as we know it won't change.
+
+		} else if i < 30 {
+			assert.Nil(t, errSend)
+		} else if i == 30 {
+
+			assert.NotNil(t, errSend)
+			assert.Equal(t, "AsyncPutFailure", errSend.GetErrorCode())
+
+			// Message should be "N failures"
+			assert.True(t, strings.Contains(errSend.GetReason(), "6 failures"))
+			assert.True(t, strings.Contains(errSend.GetReason(), "0 warnings"))
+
+			// Linked message should have reason of MQRC_Q_FULL
+			linkedErr := errSend.GetLinkedError()
+			assert.NotNil(t, linkedErr)
+			linkedReason := linkedErr.(jms20subset.JMSExceptionImpl).GetReason()
+			assert.Equal(t, "MQRC_Q_FULL", linkedReason)
+
+		} else if i == 40 {
+
+			assert.NotNil(t, errSend)
+			assert.Equal(t, "AsyncPutFailure", errSend.GetErrorCode())
+
+			// Message should be "N failures"
+			assert.True(t, strings.Contains(errSend.GetReason(), "10 failures")) // all of these failed
+			assert.True(t, strings.Contains(errSend.GetReason(), "0 warnings"))
+
+			// Linked message should have reason of MQRC_Q_FULL
+			linkedErr := errSend.GetLinkedError()
+			assert.NotNil(t, linkedErr)
+			linkedReason := linkedErr.(jms20subset.JMSExceptionImpl).GetReason()
+			assert.Equal(t, "MQRC_Q_FULL", linkedReason)
+
+		} else {
+			// Messages 31, 32, ... 39, 41, 42, ...
+			// do not give an error because we don't make an error check.
+			assert.Nil(t, errSend)
+		}
+	}
+
+	// If the queue exists then tidy up the messages we sent.
+	if queueExists {
+
+		// ----------------------------------
+		// Receive the messages back again to tidy the queue back to a clean state
+		consumer, errCons := context.CreateConsumer(asyncQueue)
+		assert.Nil(t, errCons)
+		if consumer != nil {
+			defer consumer.Close()
+		}
+
+		// Receive the messages back again
+		finishedReceiving := false
+
+		for !finishedReceiving {
+			rcvMsg, errRvc := consumer.ReceiveNoWait()
+			assert.Nil(t, errRvc)
+
+			if rcvMsg == nil {
+				finishedReceiving = true
+			}
+		}
+	}
 }
 
 /*

--- a/asyncput_test.go
+++ b/asyncput_test.go
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) IBM Corporation 2021
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
+	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
+	"github.com/stretchr/testify/assert"
+)
+
+/*
+ * Test the ability to send a message asynchronously, which can give a higher
+ * rate of sending non-persistent messages, in exchange for less/no checking for errors.
+ */
+func TestAsyncPut(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// Set up the producer and consumer with the SYNCHRONOUS (not async yet) queue
+	syncQueue := context.CreateQueue("DEV.QUEUE.1")
+	producer := context.CreateProducer().SetDeliveryMode(jms20subset.DeliveryMode_NON_PERSISTENT).SetTimeToLive(60000)
+
+	consumer, errCons := context.CreateConsumer(syncQueue)
+	assert.Nil(t, errCons)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+
+	// Create a unique message prefix representing this execution of the test case.
+	testcasePrefix := strconv.FormatInt(currentTimeMillis(), 10)
+	syncMsgPrefix := "syncput_" + testcasePrefix + "_"
+	asyncMsgPrefix := "asyncput_" + testcasePrefix + "_"
+	numberMessages := 50
+
+	// First get a baseline for how long it takes us to send the batch of messages
+	// WITHOUT async put.
+	syncStartTime := currentTimeMillis()
+	for i := 0; i < numberMessages; i++ {
+
+		// Create a TextMessage and send it.
+		msg := context.CreateTextMessageWithString(syncMsgPrefix + strconv.Itoa(i))
+
+		errSend := producer.Send(syncQueue, msg)
+		assert.Nil(t, errSend)
+	}
+	syncEndTime := currentTimeMillis()
+
+	syncSendTime := syncEndTime - syncStartTime
+	//fmt.Println("Took " + strconv.FormatInt(syncSendTime, 10) + "ms to send " + strconv.Itoa(numberMessages) + " synchronous messages.")
+
+	// Receive the messages back again
+	finishedReceiving := false
+	rcvCount := 0
+
+	for !finishedReceiving {
+		rcvTxt, errRvc := consumer.ReceiveStringBodyNoWait()
+		assert.Nil(t, errRvc)
+
+		if rcvTxt != nil {
+			// Check the message bod matches what we expect
+			assert.Equal(t, syncMsgPrefix+strconv.Itoa(rcvCount), *rcvTxt)
+			rcvCount++
+		} else {
+			finishedReceiving = true
+		}
+	}
+
+	// --------------------------------------------------------
+	// Now repeat the experiment but with ASYNC message put
+	asyncQueue := context.CreateQueue("DEV.QUEUE.1").SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED)
+
+	asyncStartTime := currentTimeMillis()
+	for i := 0; i < numberMessages; i++ {
+
+		// Create a TextMessage and send it.
+		msg := context.CreateTextMessageWithString(asyncMsgPrefix + strconv.Itoa(i))
+
+		errSend := producer.Send(asyncQueue, msg)
+		assert.Nil(t, errSend)
+	}
+	asyncEndTime := currentTimeMillis()
+
+	asyncSendTime := asyncEndTime - asyncStartTime
+	//fmt.Println("Took " + strconv.FormatInt(asyncSendTime, 10) + "ms to send " + strconv.Itoa(numberMessages) + " ASYNC messages.")
+
+	// Receive the messages back again
+	finishedReceiving = false
+	rcvCount = 0
+
+	for !finishedReceiving {
+		rcvTxt, errRvc := consumer.ReceiveStringBodyNoWait()
+		assert.Nil(t, errRvc)
+
+		if rcvTxt != nil {
+			// Check the message bod matches what we expect
+			assert.Equal(t, asyncMsgPrefix+strconv.Itoa(rcvCount), *rcvTxt)
+			rcvCount++
+		} else {
+			finishedReceiving = true
+		}
+	}
+
+	assert.Equal(t, numberMessages, rcvCount)
+
+	// Expect that async put is at least 10% faster than sync put for non-persistent messages
+	// (in testing against a remote queue manager it was actually 30% faster)
+	assert.True(t, 100*asyncSendTime < 90*syncSendTime)
+
+}
+
+/*
+ * Test the getter/setter functions for controlling async put.
+ */
+func TestAsyncPutGetterSetter(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// Set up the producer and consumer
+	queue := context.CreateQueue("DEV.QUEUE.1")
+
+	// Check the default
+	assert.Equal(t, jms20subset.Destination_PUT_ASYNC_ALLOWED_AS_DEST, queue.GetPutAsyncAllowed())
+
+	// Check enabled
+	queue = queue.SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED)
+	assert.Equal(t, jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED, queue.GetPutAsyncAllowed())
+
+	// Check disabled
+	queue = queue.SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_DISABLED)
+	assert.Equal(t, jms20subset.Destination_PUT_ASYNC_ALLOWED_DISABLED, queue.GetPutAsyncAllowed())
+
+	// Check as-dest
+	queue = queue.SetPutAsyncAllowed(jms20subset.Destination_PUT_ASYNC_ALLOWED_AS_DEST)
+	assert.Equal(t, jms20subset.Destination_PUT_ASYNC_ALLOWED_AS_DEST, queue.GetPutAsyncAllowed())
+
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ibm-messaging/mq-golang-jms20
 go 1.13
 
 require (
+	github.com/ibm-messaging/mq-golang v3.0.0+incompatible
 	github.com/ibm-messaging/mq-golang/v5 v5.1.3
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/ibm-messaging/mq-golang v1.0.1-0.20190820103725-19b946c185a8 h1:kUwSXeftVen12FRnShG+Ykhb2Kd6Cd/DbpWwbYal7j0=
 github.com/ibm-messaging/mq-golang v1.0.1-0.20190820103725-19b946c185a8/go.mod h1:qjsZDb7m1oKnbPeDma2JVJTKgyCA91I4bcJ1qHY+gcA=
 github.com/ibm-messaging/mq-golang v3.0.0+incompatible h1:Yc3c8emAyveT54uNDRMkgvS+EBAHeLNWHkc3hk5x+IY=
+github.com/ibm-messaging/mq-golang v3.0.0+incompatible/go.mod h1:qjsZDb7m1oKnbPeDma2JVJTKgyCA91I4bcJ1qHY+gcA=
 github.com/ibm-messaging/mq-golang/v5 v5.0.0 h1:9J8bsDoCo60rbSgB7ZAURPG3L5Kpr+F8dYNOwQ7Qnnk=
 github.com/ibm-messaging/mq-golang/v5 v5.0.0/go.mod h1:ywCwmYbJOU/E0rl+z4GiNoxVMty68O+LVO39a1VMXrE=
 github.com/ibm-messaging/mq-golang/v5 v5.1.2 h1:u0e1Vce2TNqJpH088vF77rDMsnMRWnGaOIlxZo4DMZc=

--- a/jms20subset/Destination.go
+++ b/jms20subset/Destination.go
@@ -26,6 +26,10 @@ type Destination interface {
 	// SetPutAsyncAllowed controls whether asynchronous put is allowed for this
 	// destination.
 	//
+	// See also ConnectionFactoryImpl.SendCheckCount to control the frequency with
+	// which checks will be made for errors. Default of 0 (zero) means no error checks
+	// will be made for errors during async put.
+	//
 	// Permitted values are:
 	//  * Destination_PUT_ASYNC_ALLOWED_ENABLED - enables async put
 	//  * Destination_PUT_ASYNC_ALLOWED_DISABLED - disables async put

--- a/jms20subset/Destination.go
+++ b/jms20subset/Destination.go
@@ -22,4 +22,32 @@ type Destination interface {
 	// is automatically implemented by every object, so we need to define at least
 	// one method here in order to make it meet the JMS style semantics.
 	GetDestinationName() string
+
+	// SetPutAsyncAllowed controls whether asynchronous put is allowed for this
+	// destination.
+	//
+	// Permitted values are:
+	//  * Destination_PUT_ASYNC_ALLOWED_ENABLED - enables async put
+	//  * Destination_PUT_ASYNC_ALLOWED_DISABLED - disables async put
+	//  * Destination_PUT_ASYNC_ALLOWED_AS_DEST - delegate to queue configuration (default)
+	SetPutAsyncAllowed(paa int) Queue
+
+	// GetPutAsyncAllowed returns whether asynchronous put is configured for this
+	// destination.
+	//
+	// Returned value is one of:
+	//  * Destination_PUT_ASYNC_ALLOWED_ENABLED - async put is enabled
+	//  * Destination_PUT_ASYNC_ALLOWED_DISABLED - async put is disabled
+	//  * Destination_PUT_ASYNC_ALLOWED_AS_DEST - delegated to queue configuration (default)
+	GetPutAsyncAllowed() int
 }
+
+// Destination_PUT_ASYNC_ALLOWED_ENABLED is used to enable messages being sent asynchronously.
+const Destination_PUT_ASYNC_ALLOWED_ENABLED int = 1
+
+// Destination_PUT_ASYNC_ALLOWED_DISABLED is used to disable messages being sent asynchronously.
+const Destination_PUT_ASYNC_ALLOWED_DISABLED int = 0
+
+// Destination_PUT_ASYNC_ALLOWED_AS_DEST allows the async message behaviour to be controlled by
+// the queue on the queue manager.
+const Destination_PUT_ASYNC_ALLOWED_AS_DEST int = -1

--- a/jms20subset/JMSContext.go
+++ b/jms20subset/JMSContext.go
@@ -69,10 +69,10 @@ type JMSContext interface {
 	CreateBytesMessageWithBytes(bytes []byte) BytesMessage
 
 	// Commit confirms all messages sent/received during this transaction.
-	Commit()
+	Commit() JMSException
 
 	// Rollback releases all messages sent/received during this transaction.
-	Rollback()
+	Rollback() JMSException
 
 	// Closes the connection to the messaging provider.
 	//

--- a/jms20subset/JMSException.go
+++ b/jms20subset/JMSException.go
@@ -19,6 +19,7 @@ type JMSException interface {
 	GetReason() string
 	GetErrorCode() string
 	GetLinkedError() error
+	Error() string
 }
 
 // JMSExceptionImpl is a struct that implements the JMSException interface

--- a/jms20subset/Queue.go
+++ b/jms20subset/Queue.go
@@ -15,14 +15,11 @@ package jms20subset
 // specifies the identity of a queue to the JMS API functions.
 type Queue interface {
 
+	// Encapsulate the root Destination type so that this interface "inherits" the
+	// accessors for standard attributes that apply to all destination types
+	Destination
+
 	// GetQueueName returns the provider-specific name of the queue that is
 	// represented by this object.
 	GetQueueName() string
-
-	// GetDestinationName returns the provider-specific name of the queue that is
-	// represented by this object.
-	//
-	// This method is implemented to allow us to consider the Queue interface
-	// as a specialization of the Destination interface.
-	GetDestinationName() string
 }

--- a/local_transaction_test.go
+++ b/local_transaction_test.go
@@ -80,7 +80,8 @@ func TestPutTransaction(t *testing.T) {
 	assert.Nil(t, rcvBody) // Expect nil here - message should not have been received.
 
 	// Commit and messages should now be available (in order)
-	transactedContext.Commit()
+	cxErr := transactedContext.Commit()
+	assert.Nil(t, cxErr)
 	rcvBody, errRcv = untransactedConsumer.ReceiveStringBodyNoWait()
 	assert.Nil(t, errRcv)
 	assert.Equal(t, bodyTxt1, *rcvBody)
@@ -101,11 +102,13 @@ func TestPutTransaction(t *testing.T) {
 	rcvBody, errRcv = untransactedConsumer.ReceiveStringBodyNoWait()
 	assert.Nil(t, errRcv)
 	assert.Nil(t, rcvBody)
-	transactedContext.Rollback() // Undo the messages
+	rbErr := transactedContext.Rollback() // Undo the messages
+	assert.Nil(t, rbErr)
 	rcvBody, errRcv = untransactedConsumer.ReceiveStringBodyNoWait()
 	assert.Nil(t, errRcv)
 	assert.Nil(t, rcvBody)
-	transactedContext.Commit() // Should no longer be under the transaction
+	cxErr = transactedContext.Commit() // Should no longer be under the transaction
+	assert.Nil(t, cxErr)
 	rcvBody, errRcv = untransactedConsumer.ReceiveStringBodyNoWait()
 	assert.Nil(t, errRcv)
 	assert.Nil(t, rcvBody)
@@ -207,7 +210,8 @@ func TestGetTransaction(t *testing.T) {
 	assert.Nil(t, rcvBody)
 
 	// rollback, messages reappear
-	transactedContext.Rollback() // puts the two messages back on the queue
+	rbErr := transactedContext.Rollback() // puts the two messages back on the queue
+	assert.Nil(t, rbErr)
 	rcvBody, errRcv = untransactedConsumer.ReceiveStringBodyNoWait()
 	assert.Nil(t, errRcv)
 	assert.Equal(t, bodyTxt1, *rcvBody)
@@ -216,7 +220,8 @@ func TestGetTransaction(t *testing.T) {
 	rcvBody, errRcv = transactedConsumer.ReceiveStringBodyNoWait()
 	assert.Nil(t, errRcv)
 	assert.Equal(t, bodyTxt2, *rcvBody)
-	transactedContext.Commit() // commit the consumption of the one message.
+	cxErr := transactedContext.Commit() // commit the consumption of the one message.
+	assert.Nil(t, cxErr)
 	rcvBody, errRcv = untransactedConsumer.ReceiveStringBodyNoWait()
 	assert.Nil(t, errRcv)
 	assert.Nil(t, rcvBody) // No message should be available
@@ -323,8 +328,9 @@ func TestPutGetTransaction(t *testing.T) {
 	assert.Nil(t, errSend)
 	rcvBody, errRcv = untransactedReqConsumer.ReceiveStringBodyNoWait()
 	assert.Nil(t, errRcv)
-	assert.Nil(t, rcvBody)           // Not yet visible for consumption
-	senderTransactedContext.Commit() // Make the message visible
+	assert.Nil(t, rcvBody)                    // Not yet visible for consumption
+	cxErr := senderTransactedContext.Commit() // Make the message visible
+	assert.Nil(t, cxErr)
 
 	// get message under transaction, put reply message to different queue
 	rcvBody, errRcv = transactedReqConsumer.ReceiveStringBodyNoWait()
@@ -343,7 +349,8 @@ func TestPutGetTransaction(t *testing.T) {
 	assert.Nil(t, rcvBody)
 
 	// rollback; request message is available, reply message is not
-	transactedContext.Rollback()
+	rbErr := transactedContext.Rollback()
+	assert.Nil(t, rbErr)
 	rcvBody, errRcv = untransactedReqConsumer.ReceiveStringBodyNoWait()
 	assert.Nil(t, errRcv)
 	assert.Equal(t, msgBody, *rcvBody)
@@ -355,7 +362,8 @@ func TestPutGetTransaction(t *testing.T) {
 	msgBody2 := "putget-transaction-2"
 	errSend = transactedReqProducer.SendString(trReqQueue, msgBody2)
 	assert.Nil(t, errSend)
-	senderTransactedContext.Commit()
+	cxErr = senderTransactedContext.Commit()
+	assert.Nil(t, cxErr)
 
 	// (again) get message under transaction, put reply message to the other queue
 	rcvBody, errRcv = transactedReqConsumer.ReceiveStringBodyNoWait()
@@ -366,7 +374,8 @@ func TestPutGetTransaction(t *testing.T) {
 	assert.Nil(t, errSend)
 
 	// commit; request message is gone, and reply message is available
-	transactedContext.Commit()
+	cxErr = transactedContext.Commit()
+	assert.Nil(t, cxErr)
 	rcvBody, errRcv = untransactedReqConsumer.ReceiveStringBodyNoWait()
 	assert.Nil(t, errRcv)
 	assert.Nil(t, rcvBody)

--- a/mqjms/ContextImpl.go
+++ b/mqjms/ContextImpl.go
@@ -138,20 +138,46 @@ func (ctx ContextImpl) CreateBytesMessageWithBytes(bytes []byte) jms20subset.Byt
 }
 
 // Commit confirms all messages that were sent under this transaction.
-func (ctx ContextImpl) Commit() {
+func (ctx ContextImpl) Commit() jms20subset.JMSException {
+
+	var retErr jms20subset.JMSException
 
 	if (ibmmq.MQQueueManager{}) != ctx.qMgr {
-		ctx.qMgr.Cmit()
+		err := ctx.qMgr.Cmit()
+
+		if err != nil {
+
+			rcInt := int(err.(*ibmmq.MQReturn).MQRC)
+			errCode := strconv.Itoa(rcInt)
+			reason := ibmmq.MQItoString("RC", rcInt)
+			retErr = jms20subset.CreateJMSException(reason, errCode, err)
+
+		}
+
 	}
 
+	return retErr
 }
 
 // Rollback releases all messages that were sent under this transaction.
-func (ctx ContextImpl) Rollback() {
+func (ctx ContextImpl) Rollback() jms20subset.JMSException {
+
+	var retErr jms20subset.JMSException
 
 	if (ibmmq.MQQueueManager{}) != ctx.qMgr {
-		ctx.qMgr.Back()
+		err := ctx.qMgr.Back()
+
+		if err != nil {
+
+			rcInt := int(err.(*ibmmq.MQReturn).MQRC)
+			errCode := strconv.Itoa(rcInt)
+			reason := ibmmq.MQItoString("RC", rcInt)
+			retErr = jms20subset.CreateJMSException(reason, errCode, err)
+
+		}
 	}
+
+	return retErr
 
 }
 

--- a/mqjms/ContextImpl.go
+++ b/mqjms/ContextImpl.go
@@ -22,6 +22,8 @@ type ContextImpl struct {
 	qMgr              ibmmq.MQQueueManager
 	sessionMode       int
 	receiveBufferSize int
+	sendCheckCount    int
+	sendCheckCountInc *int // Internal counter to keep track of async-put messages sent
 }
 
 // CreateQueue implements the logic necessary to create a provider-specific

--- a/mqjms/ContextImpl.go
+++ b/mqjms/ContextImpl.go
@@ -30,7 +30,8 @@ func (ctx ContextImpl) CreateQueue(queueName string) jms20subset.Queue {
 
 	// Store the name of the queue
 	queue := QueueImpl{
-		queueName: queueName,
+		queueName:       queueName,
+		putAsyncAllowed: jms20subset.Destination_PUT_ASYNC_ALLOWED_AS_DEST,
 	}
 
 	return queue

--- a/mqjms/ProducerImpl.go
+++ b/mqjms/ProducerImpl.go
@@ -91,6 +91,11 @@ func (producer ProducerImpl) Send(dest jms20subset.Destination, msg jms20subset.
 		// unique message ID
 		pmo.Options = syncpointSetting | ibmmq.MQPMO_NEW_MSG_ID
 
+		// Is async put has been requested then apply the appropriate PMO option
+		if dest.GetPutAsyncAllowed() == jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED {
+			pmo.Options |= ibmmq.MQPMO_ASYNC_RESPONSE
+		}
+
 		// Convert the JMS persistence into the equivalent MQ message descriptor
 		// attribute.
 		if producer.deliveryMode == jms20subset.DeliveryMode_NON_PERSISTENT {

--- a/mqjms/QueueImpl.go
+++ b/mqjms/QueueImpl.go
@@ -9,10 +9,18 @@
 // Package mqjms provides the implementation of the JMS style Golang interfaces to communicate with IBM MQ.
 package mqjms
 
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
+)
+
 // QueueImpl encapsulates the provider-specific attributes necessary to
 // communicate with an IBM MQ queue.
 type QueueImpl struct {
-	queueName string
+	queueName       string
+	putAsyncAllowed int
 }
 
 // GetQueueName returns the provider-specific name of the queue that is
@@ -29,4 +37,31 @@ func (queue QueueImpl) GetDestinationName() string {
 
 	return queue.queueName
 
+}
+
+// SetPutAsyncAllowed allows the async allowed setting to be updated.
+func (queue QueueImpl) SetPutAsyncAllowed(paa int) jms20subset.Queue {
+
+	// Check that the specified paa parameter is one of the values that we permit,
+	// and if so store that value inside queue.
+	if paa == jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED ||
+		paa == jms20subset.Destination_PUT_ASYNC_ALLOWED_DISABLED ||
+		paa == jms20subset.Destination_PUT_ASYNC_ALLOWED_AS_DEST {
+
+		queue.putAsyncAllowed = paa
+
+	} else {
+		// Normally we would throw an error here to indicate that an invalid value
+		// was specified, however we have decided that it is more useful to support
+		// method chaining, which prevents us from returning an error object.
+		// Instead we settle for printing an error message to the console.
+		fmt.Println("Invalid PutAsyncAllowed value specified: " + strconv.Itoa(paa))
+	}
+
+	return queue
+}
+
+// GetPutAsyncAllowed returns the current setting for async put.
+func (queue QueueImpl) GetPutAsyncAllowed() int {
+	return queue.putAsyncAllowed
 }


### PR DESCRIPTION

- Asynchronous Put of non-persistent messages in a non-transacted Context (session)
  - Observed to be around 30% faster than the normal synchronous put in a testcase involving a laptop-hosted client application that is client connected to a queue manager running in IBM Cloud
  - Default ConnectionFactoryImpl.SendCheckCount of zero (0) means no check for errors will ever be made
  - Set a positive SendCheckCount to indicate how many async put messages should be sent between error checks
  - Errors detected are returned on the response to the Send() call
- Asynchronous Put of persistent messages inside a transacted Context
  - Also observed to be 30% faster than synchronous put in test scenario
  - No errors are reported on the Send() call
  - Instead failures are reported on Commit()
- Asynchronous Put of non-persistent messages inside a transacted Context
  - No errors are ever reported - the application is not able to determine whether those messages were sent successfully or not 
- Testcases demonstrating the behaviour in `asyncput_test.go`

- Noted that this PR also adds JMSException return value for Commit and Rollback, but these are backwards compatible since as piece of application code that calls Commit without expecting a response (as before this PR) continues to compile successfully after this change.  Users are then able to update their application code to check for errors at their own discretion if they wish.


I accept the terms of the Contributor License Agreement.