### PR TITLE
use mqput1 instead of mqopen mqput and mqclose, closes #37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 mq-golang-jms20.test
 vendor
 .DS_Store
+.idea

--- a/largemessage_test.go
+++ b/largemessage_test.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -299,7 +300,7 @@ func getStringOver32kb() string {
 	// Build a text string which is over 32KB (in a not very efficient way!)
 	// First snippet is 100 chars long.
 	txt100chars := "The quick brown fox jumped over the lazy dog into the flowing river that rushed over the cliff edge."
-	txt1300chars := string(time.Now().UnixNano()) + txt100chars + txt100chars + txt100chars + txt100chars + txt100chars +
+	txt1300chars := strconv.FormatInt(time.Now().UnixNano(), 10) + txt100chars + txt100chars + txt100chars + txt100chars + txt100chars +
 		txt100chars + txt100chars + txt100chars + txt100chars + txt100chars +
 		txt100chars + txt100chars + txt100chars
 

--- a/mqjms/ProducerImpl.go
+++ b/mqjms/ProducerImpl.go
@@ -58,153 +58,137 @@ func (producer ProducerImpl) Send(dest jms20subset.Destination, msg jms20subset.
 
 	// Set up the basic objects we need to send the message.
 	mqod := ibmmq.NewMQOD()
-
-	var openOptions int32
-	openOptions = ibmmq.MQOO_OUTPUT + ibmmq.MQOO_FAIL_IF_QUIESCING
-	openOptions |= ibmmq.MQOO_INPUT_AS_Q_DEF
-
-	mqod.ObjectType = ibmmq.MQOT_Q
-	mqod.ObjectName = dest.GetDestinationName()
+	putmqmd := ibmmq.NewMQMD()
+	pmo := ibmmq.NewMQPMO()
 
 	var retErr jms20subset.JMSException
 
-	// Invoke the MQ command to open the queue, and register a defer hook
-	// to automatically close the object once we exit this function.
-	qObject, err := producer.ctx.qMgr.Open(mqod, openOptions)
-	if (ibmmq.MQObject{}) != qObject {
-		defer qObject.Close(0)
+	// Setup destination
+	mqod.ObjectType = ibmmq.MQOT_Q
+	mqod.ObjectName = dest.GetDestinationName()
+
+	// Calculate the syncpoint value
+	syncpointSetting := ibmmq.MQPMO_NO_SYNCPOINT
+	if producer.ctx.sessionMode == jms20subset.JMSContextSESSIONTRANSACTED {
+		syncpointSetting = ibmmq.MQPMO_SYNCPOINT
 	}
 
-	if err == nil {
+	// Configure the put message options, including asking MQ to allocate a
+	// unique message ID
+	pmo.Options = syncpointSetting | ibmmq.MQPMO_NEW_MSG_ID
 
-		// Successfully opened the queue, so now prepare to send the message.
-		putmqmd := ibmmq.NewMQMD()
-		pmo := ibmmq.NewMQPMO()
+	// Is async put has been requested then apply the appropriate PMO option
+	if dest.GetPutAsyncAllowed() == jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED {
+		pmo.Options |= ibmmq.MQPMO_ASYNC_RESPONSE
+	}
 
-		// Calculate the syncpoint value
-		syncpointSetting := ibmmq.MQPMO_NO_SYNCPOINT
-		if producer.ctx.sessionMode == jms20subset.JMSContextSESSIONTRANSACTED {
-			syncpointSetting = ibmmq.MQPMO_SYNCPOINT
+	// Convert the JMS persistence into the equivalent MQ message descriptor
+	// attribute.
+	if producer.deliveryMode == jms20subset.DeliveryMode_NON_PERSISTENT {
+		putmqmd.Persistence = ibmmq.MQPER_NOT_PERSISTENT
+	} else {
+		putmqmd.Persistence = ibmmq.MQPER_PERSISTENT
+	}
+
+	var buffer []byte
+
+	// We have a "Message" object and can use a switch to safely convert it
+	// to the implementation type in order to extract generic MQ message
+	switch typedMsg := msg.(type) {
+	case *TextMessageImpl:
+
+		// If the message already has an MQMD then use that (for example it might
+		// contain ReplyTo information)
+		if typedMsg.mqmd != nil {
+			putmqmd = typedMsg.mqmd
 		}
 
-		// Configure the put message options, including asking MQ to allocate a
-		// unique message ID
-		pmo.Options = syncpointSetting | ibmmq.MQPMO_NEW_MSG_ID
+		// Store the Put MQMD so that we can later retrieve "out" fields like MsgId
+		typedMsg.mqmd = putmqmd
 
-		// Is async put has been requested then apply the appropriate PMO option
-		if dest.GetPutAsyncAllowed() == jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED {
-			pmo.Options |= ibmmq.MQPMO_ASYNC_RESPONSE
+		// Set up this MQ message to contain the string from the JMS message.
+		putmqmd.Format = ibmmq.MQFMT_STRING
+		msgStr := typedMsg.GetText()
+		if msgStr != nil {
+			buffer = []byte(*msgStr)
 		}
 
-		// Convert the JMS persistence into the equivalent MQ message descriptor
-		// attribute.
-		if producer.deliveryMode == jms20subset.DeliveryMode_NON_PERSISTENT {
-			putmqmd.Persistence = ibmmq.MQPER_NOT_PERSISTENT
-		} else {
-			putmqmd.Persistence = ibmmq.MQPER_PERSISTENT
+	case *BytesMessageImpl:
+
+		// If the message already has an MQMD then use that (for example it might
+		// contain ReplyTo information)
+		if typedMsg.mqmd != nil {
+			putmqmd = typedMsg.mqmd
 		}
 
-		var buffer []byte
+		// Store the Put MQMD so that we can later retrieve "out" fields like MsgId
+		typedMsg.mqmd = putmqmd
 
-		// We have a "Message" object and can use a switch to safely convert it
-		// to the implementation type in order to extract generic MQ message
-		switch typedMsg := msg.(type) {
-		case *TextMessageImpl:
+		// Set up this MQ message to contain the bytes from the JMS message.
+		putmqmd.Format = ibmmq.MQFMT_NONE
+		buffer = *typedMsg.ReadBytes()
 
-			// If the message already has an MQMD then use that (for example it might
-			// contain ReplyTo information)
-			if typedMsg.mqmd != nil {
-				putmqmd = typedMsg.mqmd
-			}
+	default:
+		// This "should never happen"(!) apart from in situations where we are
+		// part way through adding support for a new message type to this library.
+		log.Fatal(jms20subset.CreateJMSException("UnexpectedMessageType", "UnexpectedMessageType-send1", nil))
+	}
 
-			// Store the Put MQMD so that we can later retrieve "out" fields like MsgId
-			typedMsg.mqmd = putmqmd
+	// If the producer has a TTL specified then apply it to the put MQMD so
+	// that MQ will honour it.
+	if producer.timeToLive > 0 {
+		// Note that JMS timeToLive in milliseconds, whereas MQMD Expiry expects
+		// 10ths of a second
+		putmqmd.Expiry = (int32(producer.timeToLive) / 100)
+	}
 
-			// Set up this MQ message to contain the string from the JMS message.
-			putmqmd.Format = ibmmq.MQFMT_STRING
-			msgStr := typedMsg.GetText()
-			if msgStr != nil {
-				buffer = []byte(*msgStr)
-			}
+	// Invoke the MQ command to put the message using MQPUT1 to avoid MQOPEN and MQCLOSE.
+	// Any Err that occurs will be handled below.
+	err := producer.ctx.qMgr.Put1(mqod, putmqmd, pmo, buffer)
 
-		case *BytesMessageImpl:
+	// If the user is using non-transactional async-put and requested non-zero send check
+	// count then this is the point at which we carry out the check for errors.
+	//
+	// Note that if there is already an error returned from Put then just pass that back to
+	// the user (only go into this if err is nil).
+	if dest.GetPutAsyncAllowed() == jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED &&
+		syncpointSetting == ibmmq.MQPMO_NO_SYNCPOINT &&
+		producer.ctx.sendCheckCount > 0 &&
+		err == nil {
 
-			// If the message already has an MQMD then use that (for example it might
-			// contain ReplyTo information)
-			if typedMsg.mqmd != nil {
-				putmqmd = typedMsg.mqmd
-			}
+		// Decrement the counter to indicate that a message has been put
+		*producer.ctx.sendCheckCountInc--
 
-			// Store the Put MQMD so that we can later retrieve "out" fields like MsgId
-			typedMsg.mqmd = putmqmd
-
-			// Set up this MQ message to contain the bytes from the JMS message.
-			putmqmd.Format = ibmmq.MQFMT_NONE
-			buffer = *typedMsg.ReadBytes()
-
-		default:
-			// This "should never happen"(!) apart from in situations where we are
-			// part way through adding support for a new message type to this library.
-			log.Fatal(jms20subset.CreateJMSException("UnexpectedMessageType", "UnexpectedMessageType-send1", nil))
-		}
-
-		// If the producer has a TTL specified then apply it to the put MQMD so
-		// that MQ will honour it.
-		if producer.timeToLive > 0 {
-			// Note that JMS timeToLive in milliseconds, whereas MQMD Expiry expects
-			// 10ths of a second
-			putmqmd.Expiry = (int32(producer.timeToLive) / 100)
-		}
-
-		// Invoke the MQ command to put the message.
-		// Any Err that occurs will be handled below.
-		err = qObject.Put(putmqmd, pmo, buffer)
-
-		// If the user is using non-transactional async-put and requested non-zero send check
-		// count then this is the point at which we carry out the check for errors.
+		// If we have reached zero then it is time to do an error check.
 		//
-		// Note that if there is already an error returned from Put then just pass that back to
-		// the user (only go into this if err is nil).
-		if dest.GetPutAsyncAllowed() == jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED &&
-			syncpointSetting == ibmmq.MQPMO_NO_SYNCPOINT &&
-			producer.ctx.sendCheckCount > 0 &&
-			err == nil {
+		// Note that the counter is initialized to 1 (in ConnectionFactoryImpl.go) when
+		// first configured so that we carry out an error check after the first message
+		// in order to catch any errors quickly. After that the check takes place at the
+		// interval the user requested in ConnectionFactoryImpl.SendCheckCount
+		if *producer.ctx.sendCheckCountInc == 0 {
 
-			// Decrement the counter to indicate that a message has been put
-			*producer.ctx.sendCheckCountInc--
+			// Reset the counter back to the check interval so that we wait until
+			// the necessary number of messages have been sent before running the
+			// next error check.
+			*producer.ctx.sendCheckCountInc = producer.ctx.sendCheckCount
 
-			// If we have reached zero then it is time to do an error check.
-			//
-			// Note that the counter is initialized to 1 (in ConnectionFactoryImpl.go) when
-			// first configured so that we carry out an error check after the first message
-			// in order to catch any errors quickly. After that the check takes place at the
-			// interval the user requested in ConnectionFactoryImpl.SendCheckCount
-			if *producer.ctx.sendCheckCountInc == 0 {
+			// Invoke the Stat call agains the queue manager to check for errors.
+			sts := ibmmq.NewMQSTS()
+			statErr := producer.ctx.qMgr.Stat(ibmmq.MQSTAT_TYPE_ASYNC_ERROR, sts)
 
-				// Reset the counter back to the check interval so that we wait until
-				// the necessary number of messages have been sent before running the
-				// next error check.
-				*producer.ctx.sendCheckCountInc = producer.ctx.sendCheckCount
+			if statErr != nil {
 
-				// Invoke the Stat call agains the queue manager to check for errors.
-				sts := ibmmq.NewMQSTS()
-				statErr := producer.ctx.qMgr.Stat(ibmmq.MQSTAT_TYPE_ASYNC_ERROR, sts)
+				// Problem occurred invoking the Stat call, pass this back to
+				// the user.
+				err = statErr
 
-				if statErr != nil {
+			} else {
 
-					// Problem occurred invoking the Stat call, pass this back to
-					// the user.
-					err = statErr
+				// If there are any Warnings or Failures then we have found a problem that
+				// needs to be reported to the user.
+				if sts.PutWarningCount+sts.PutFailureCount > 0 {
 
-				} else {
-
-					// If there are any Warnings or Failures then we have found a problem that
-					// needs to be reported to the user.
-					if sts.PutWarningCount+sts.PutFailureCount > 0 {
-
-						retErr = populateAsyncPutError(sts)
-
-					}
+					retErr = populateAsyncPutError(sts)
 
 				}
 
@@ -212,25 +196,25 @@ func (producer ProducerImpl) Send(dest jms20subset.Destination, msg jms20subset.
 
 		}
 
-		// If the user is using transactional async-put of persistent messages then we need to
-		// inform the ContextImpl object that an async-put message has been sent, so that it can
-		// check for failures when the Commit call is made.
-		//
-		// No error checks are made for non-persistent async put messages under a transaction,
-		// and the application does not receive any feedback whether those messages arrived safely.
-		//
-		// Note that if there is already an error returned from Put then just pass that back to
-		// the user (only go into this if err is nil).
-		if dest.GetPutAsyncAllowed() == jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED &&
-			syncpointSetting == ibmmq.MQPMO_SYNCPOINT &&
-			putmqmd.Persistence == ibmmq.MQPER_PERSISTENT &&
-			*producer.ctx.sendCheckCountInc != ContextImpl_TRANSACTED_ASYNCPUT_ACTIVE &&
-			err == nil {
+	}
 
-			// Set the flag to indicate the a transacted async put has taken place.
-			*producer.ctx.sendCheckCountInc = ContextImpl_TRANSACTED_ASYNCPUT_ACTIVE
-		}
+	// If the user is using transactional async-put of persistent messages then we need to
+	// inform the ContextImpl object that an async-put message has been sent, so that it can
+	// check for failures when the Commit call is made.
+	//
+	// No error checks are made for non-persistent async put messages under a transaction,
+	// and the application does not receive any feedback whether those messages arrived safely.
+	//
+	// Note that if there is already an error returned from Put then just pass that back to
+	// the user (only go into this if err is nil).
+	if dest.GetPutAsyncAllowed() == jms20subset.Destination_PUT_ASYNC_ALLOWED_ENABLED &&
+		syncpointSetting == ibmmq.MQPMO_SYNCPOINT &&
+		putmqmd.Persistence == ibmmq.MQPER_PERSISTENT &&
+		*producer.ctx.sendCheckCountInc != ContextImpl_TRANSACTED_ASYNCPUT_ACTIVE &&
+		err == nil {
 
+		// Set the flag to indicate the a transacted async put has taken place.
+		*producer.ctx.sendCheckCountInc = ContextImpl_TRANSACTED_ASYNCPUT_ACTIVE
 	}
 
 	// Note that the following block handles errors for both opening the queue


### PR DESCRIPTION
Features:
 - JMSProducer implementation update, now it uses MQPUT1 instead of MQOPEN MQPUT and MQCLOSE, which will represents a cheapest operation when putting messages to MQ. closes #37 

Feel free to suggest changes.

I accept the terms of the Contributor License Agreement.