### PR TITLE
Fix index out of range, closes #40

### DIFF
--- a/getbycorrelid_test.go
+++ b/getbycorrelid_test.go
@@ -202,4 +202,9 @@ func TestCorrelIDParsing(t *testing.T) {
 	msg.SetJMSCorrelationID(testCorrel)
 	assert.Equal(t, testCorrel, msg.GetJMSCorrelationID())
 
+	// Empty correlationID
+	testCorrel = "000000000000000000000000000000000000000000000000"
+	msg.SetJMSCorrelationID(testCorrel)
+	assert.Equal(t, "", msg.GetJMSCorrelationID())
+
 }

--- a/mqjms/MessageImpl.go
+++ b/mqjms/MessageImpl.go
@@ -175,10 +175,8 @@ func (msg *MessageImpl) GetJMSCorrelationID() string {
 		// Here we identify any padding zero bytes to trim off so that we can try
 		// to turn it back into a string.
 		realLength := len(correlIDBytes)
-		if realLength > 0 {
-			for correlIDBytes[realLength-1] == 0 {
-				realLength--
-			}
+		for realLength > 0 && correlIDBytes[realLength-1] == 0 {
+			realLength--
 		}
 
 		// Attempt to decode the content back into a string.


### PR DESCRIPTION
Change this fragment of code to avoid index out of range error, closes #40 

Current
```
if realLength > 0 {
	for correlIDBytes[realLength-1] == 0 {
		realLength--
	}
}
```

New
```golang
for realLength > 0 && correlIDBytes[realLength-1] == 0 {
	realLength--
}
```

I accept the terms of the Contributor License Agreement.