### PR TITLE
Support for message properties - #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ your own error handling or logging.
 * Send/receive a slice of bytes (BytesMessage) - [bytesmessage_test.go](bytesmessage_test.go)
 * Receive with wait [receivewithwait_test.go](receivewithwait_test.go)
 * Send a message as Persistent or NonPersistent - [deliverymode_test.go](deliverymode_test.go)
+* Set a message property of type string, int, double or boolean - [messageproperties_test.go](messageproperties_test.go)
 * Get by CorrelationID - [getbycorrelid_test.go](getbycorrelid_test.go)
 * Request/reply messaging pattern - [requestreply_test.go](requestreply_test.go)
 * Send and receive under a local transaction - [local_transaction_test.go](local_transaction_test.go)

--- a/bytesmessage_test.go
+++ b/bytesmessage_test.go
@@ -89,7 +89,7 @@ func TestBytesMessageNilBody(t *testing.T) {
 		assert.Equal(t, 0, msg2.GetBodyLength())
 		assert.Equal(t, []byte{}, *msg2.ReadBytes())
 	default:
-		assert.Fail(t, "Got something other than a text message")
+		assert.Fail(t, "Got something other than a bytes message")
 	}
 
 }
@@ -138,7 +138,7 @@ func TestBytesMessageWithBody(t *testing.T) {
 		assert.Equal(t, len(msgBody), msg2.GetBodyLength())
 		assert.Equal(t, msgBody, *msg2.ReadBytes())
 	default:
-		assert.Fail(t, "Got something other than a text message")
+		assert.Fail(t, "Got something other than a bytes message")
 	}
 
 }
@@ -186,7 +186,7 @@ func TestBytesMessageInitWithBytes(t *testing.T) {
 		assert.Equal(t, len(msgBody), msg2.GetBodyLength())
 		assert.Equal(t, msgBody, *msg2.ReadBytes())
 	default:
-		assert.Fail(t, "Got something other than a text message")
+		assert.Fail(t, "Got something other than a bytes message")
 	}
 
 }
@@ -231,7 +231,7 @@ func TestBytesMessageProducerSendBytes(t *testing.T) {
 		assert.Equal(t, 13, msg2.GetBodyLength())
 		assert.Equal(t, msgBody, *msg2.ReadBytes())
 	default:
-		assert.Fail(t, "Got something other than a text message")
+		assert.Fail(t, "Got something other than a bytes message")
 	}
 
 }

--- a/jms20subset/Message.go
+++ b/jms20subset/Message.go
@@ -47,4 +47,7 @@ type Message interface {
 	// Typical values returned by this method include
 	// jms20subset.DeliveryMode_PERSISTENT and jms20subset.DeliveryMode_NON_PERSISTENT
 	GetJMSDeliveryMode() int
+
+	SetStringProperty(name string, value string) JMSException
+	GetStringProperty(name string) *string
 }

--- a/jms20subset/Message.go
+++ b/jms20subset/Message.go
@@ -72,6 +72,13 @@ type Message interface {
 	// Returns 0 if the named property is not set.
 	GetDoubleProperty(name string) (float64, JMSException)
 
+	// SetBooleanProperty enables an application to set a bool-type message property.
+	SetBooleanProperty(name string, value bool) JMSException
+
+	// GetBooleanProperty returns the bool value of a named message property.
+	// Returns false if the named property is not set.
+	GetBooleanProperty(name string) (bool, JMSException)
+
 	// PropertyExists returns true if the named message property exists on this message.
 	PropertyExists(name string) (bool, JMSException)
 

--- a/jms20subset/Message.go
+++ b/jms20subset/Message.go
@@ -48,19 +48,24 @@ type Message interface {
 	// jms20subset.DeliveryMode_PERSISTENT and jms20subset.DeliveryMode_NON_PERSISTENT
 	GetJMSDeliveryMode() int
 
-	// TODO documentation
+	// SetStringProperty enables an application to set a string-type message property.
+	//
+	// value is *string which allows a nil value to be specified, to unset an individual
+	// property.
 	SetStringProperty(name string, value *string) JMSException
 
-	// TODO documentation
-	// Returns string property, or nil if the property is not set.
+	// GetStringProperty returns the string value of a named message property.
+	// Returns nil if the named property is not set.
 	GetStringProperty(name string) *string
 
-	// TODO documentation
+	// PropertyExists returns true if the named message property exists on this message.
 	PropertyExists(name string) (bool, JMSException)
 
-	// TODO documentation
+	// GetPropertyNames returns a slice of strings containing the name of every message
+	// property on this message.
+	// Returns a zero length slice if no message properties are defined.
 	GetPropertyNames() ([]string, JMSException)
 
-	// TODO documentation
+	// ClearProperties removes all message properties from this message.
 	ClearProperties() JMSException
 }

--- a/jms20subset/Message.go
+++ b/jms20subset/Message.go
@@ -65,6 +65,13 @@ type Message interface {
 	// Returns 0 if the named property is not set.
 	GetIntProperty(name string) (int, JMSException)
 
+	// SetDoubleProperty enables an application to set a double-type (float64) message property.
+	SetDoubleProperty(name string, value float64) JMSException
+
+	// GetDoubleProperty returns the double (float64) value of a named message property.
+	// Returns 0 if the named property is not set.
+	GetDoubleProperty(name string) (float64, JMSException)
+
 	// PropertyExists returns true if the named message property exists on this message.
 	PropertyExists(name string) (bool, JMSException)
 

--- a/jms20subset/Message.go
+++ b/jms20subset/Message.go
@@ -58,6 +58,13 @@ type Message interface {
 	// Returns nil if the named property is not set.
 	GetStringProperty(name string) (*string, JMSException)
 
+	// SetIntProperty enables an application to set a int-type message property.
+	SetIntProperty(name string, value int) JMSException
+
+	// GetIntProperty returns the int value of a named message property.
+	// Returns 0 if the named property is not set.
+	GetIntProperty(name string) (int, JMSException)
+
 	// PropertyExists returns true if the named message property exists on this message.
 	PropertyExists(name string) (bool, JMSException)
 

--- a/jms20subset/Message.go
+++ b/jms20subset/Message.go
@@ -48,8 +48,19 @@ type Message interface {
 	// jms20subset.DeliveryMode_PERSISTENT and jms20subset.DeliveryMode_NON_PERSISTENT
 	GetJMSDeliveryMode() int
 
+	// TODO documentation
 	SetStringProperty(name string, value *string) JMSException
 
+	// TODO documentation
 	// Returns string property, or nil if the property is not set.
 	GetStringProperty(name string) *string
+
+	// TODO documentation
+	PropertyExists(name string) (bool, JMSException)
+
+	// TODO documentation
+	GetPropertyNames() ([]string, JMSException)
+
+	// TODO documentation
+	ClearProperties() JMSException
 }

--- a/jms20subset/Message.go
+++ b/jms20subset/Message.go
@@ -56,7 +56,7 @@ type Message interface {
 
 	// GetStringProperty returns the string value of a named message property.
 	// Returns nil if the named property is not set.
-	GetStringProperty(name string) *string
+	GetStringProperty(name string) (*string, JMSException)
 
 	// PropertyExists returns true if the named message property exists on this message.
 	PropertyExists(name string) (bool, JMSException)

--- a/jms20subset/Message.go
+++ b/jms20subset/Message.go
@@ -84,7 +84,7 @@ type Message interface {
 
 	// GetPropertyNames returns a slice of strings containing the name of every message
 	// property on this message.
-	// Returns a zero length slice if no message properties are defined.
+	// Returns a zero length slice if no message properties are set.
 	GetPropertyNames() ([]string, JMSException)
 
 	// ClearProperties removes all message properties from this message.

--- a/jms20subset/Message.go
+++ b/jms20subset/Message.go
@@ -48,6 +48,8 @@ type Message interface {
 	// jms20subset.DeliveryMode_PERSISTENT and jms20subset.DeliveryMode_NON_PERSISTENT
 	GetJMSDeliveryMode() int
 
-	SetStringProperty(name string, value string) JMSException
+	SetStringProperty(name string, value *string) JMSException
+
+	// Returns string property, or nil if the property is not set.
 	GetStringProperty(name string) *string
 }

--- a/messageproperties_test.go
+++ b/messageproperties_test.go
@@ -55,12 +55,16 @@ func TestStringPropertyTextMsg(t *testing.T) {
 	propValue := "myValue"
 
 	// Test the empty value before the property is set.
-	assert.Nil(t, txtMsg.GetStringProperty(propName))
+	gotPropValue, propErr := txtMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 
 	// Test the ability to set properties before the message is sent.
 	retErr := txtMsg.SetStringProperty(propName, &propValue)
 	assert.Nil(t, retErr)
-	assert.Equal(t, propValue, *txtMsg.GetStringProperty(propName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, propValue, *gotPropValue)
 	assert.Equal(t, msgBody, *txtMsg.GetText())
 
 	// Send an empty string property as well
@@ -68,17 +72,23 @@ func TestStringPropertyTextMsg(t *testing.T) {
 	emptyPropValue := ""
 	retErr = txtMsg.SetStringProperty(emptyPropName, &emptyPropValue)
 	assert.Nil(t, retErr)
-	assert.Equal(t, emptyPropValue, *txtMsg.GetStringProperty(emptyPropName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(emptyPropName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, emptyPropValue, *gotPropValue)
 
 	// Set a property then try to unset it by setting to nil
 	unsetPropName := "mySendThenRemovedString"
 	unsetPropValue := "someValueThatWillBeOverwritten"
 	retErr = txtMsg.SetStringProperty(unsetPropName, &unsetPropValue)
 	assert.Nil(t, retErr)
-	assert.Equal(t, unsetPropValue, *txtMsg.GetStringProperty(unsetPropName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(unsetPropName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, unsetPropValue, *gotPropValue)
 	retErr = txtMsg.SetStringProperty(unsetPropName, nil)
 	assert.Nil(t, retErr)
-	assert.Nil(t, txtMsg.GetStringProperty(unsetPropName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(unsetPropName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 
 	// Set up objects for send/receive
 	queue := context.CreateQueue("DEV.QUEUE.1")
@@ -104,14 +114,22 @@ func TestStringPropertyTextMsg(t *testing.T) {
 	}
 
 	// Check property is available on received message.
-	assert.Equal(t, propValue, *rcvMsg.GetStringProperty(propName))
+	gotPropValue, propErr = rcvMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, propValue, *gotPropValue)
 
 	// Check the empty string property.
-	assert.Equal(t, emptyPropValue, *rcvMsg.GetStringProperty(emptyPropName))
+	gotPropValue, propErr = rcvMsg.GetStringProperty(emptyPropName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, emptyPropValue, *gotPropValue)
 
 	// Properties that are not set should return nil
-	assert.Nil(t, rcvMsg.GetStringProperty("nonExistentProperty"))
-	assert.Nil(t, rcvMsg.GetStringProperty(unsetPropName))
+	gotPropValue, propErr = rcvMsg.GetStringProperty("nonExistentProperty")
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
+	gotPropValue, propErr = rcvMsg.GetStringProperty(unsetPropName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 
 }
 
@@ -141,7 +159,9 @@ func TestPropertyExistsGetNames(t *testing.T) {
 	propValue := "myValue"
 
 	// Test the empty value before the property is set.
-	assert.Nil(t, txtMsg.GetStringProperty(propName))
+	gotPropValue, propErr := txtMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 	propExists, propErr := txtMsg.PropertyExists(propName)
 	assert.Nil(t, propErr)
 	assert.False(t, propExists)
@@ -152,7 +172,9 @@ func TestPropertyExistsGetNames(t *testing.T) {
 	// Test the ability to set properties before the message is sent.
 	retErr := txtMsg.SetStringProperty(propName, &propValue)
 	assert.Nil(t, retErr)
-	assert.Equal(t, propValue, *txtMsg.GetStringProperty(propName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, propValue, *gotPropValue)
 	propExists, propErr = txtMsg.PropertyExists(propName)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists) // now exists
@@ -165,7 +187,9 @@ func TestPropertyExistsGetNames(t *testing.T) {
 	propValue2 := "myValueTwo"
 	retErr = txtMsg.SetStringProperty(propName2, &propValue2)
 	assert.Nil(t, retErr)
-	assert.Equal(t, propValue2, *txtMsg.GetStringProperty(propName2))
+	gotPropValue, propErr = txtMsg.GetStringProperty(propName2)
+	assert.Nil(t, propErr)
+	assert.Equal(t, propValue2, *gotPropValue)
 	propExists, propErr = txtMsg.PropertyExists(propName2)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists) // now exists
@@ -184,7 +208,9 @@ func TestPropertyExistsGetNames(t *testing.T) {
 	unsetPropValue := "someValueThatWillBeOverwritten"
 	retErr = txtMsg.SetStringProperty(unsetPropName, &unsetPropValue)
 	assert.Nil(t, retErr)
-	assert.Equal(t, unsetPropValue, *txtMsg.GetStringProperty(unsetPropName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(unsetPropName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, unsetPropValue, *gotPropValue)
 	propExists, propErr = txtMsg.PropertyExists(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists)
@@ -193,7 +219,9 @@ func TestPropertyExistsGetNames(t *testing.T) {
 	assert.Equal(t, 3, len(allPropNames))
 	retErr = txtMsg.SetStringProperty(unsetPropName, nil)
 	assert.Nil(t, retErr)
-	assert.Nil(t, txtMsg.GetStringProperty(unsetPropName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(unsetPropName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 	propExists, propErr = txtMsg.PropertyExists(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.False(t, propExists)
@@ -242,7 +270,9 @@ func TestPropertyExistsGetNames(t *testing.T) {
 
 	// Properties that are not set should return nil
 	nonExistentPropName := "nonExistentProperty"
-	assert.Nil(t, rcvMsg.GetStringProperty(nonExistentPropName))
+	gotPropValue, propErr = rcvMsg.GetStringProperty(nonExistentPropName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 	propExists, propErr = rcvMsg.PropertyExists(nonExistentPropName)
 	assert.Nil(t, propErr)
 	assert.False(t, propExists)
@@ -282,7 +312,9 @@ func TestPropertyClearProperties(t *testing.T) {
 	// Test the ability to set properties before the message is sent.
 	retErr := txtMsg.SetStringProperty(propName, &propValue)
 	assert.Nil(t, retErr)
-	assert.Equal(t, propValue, *txtMsg.GetStringProperty(propName))
+	gotPropValue, propErr := txtMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, propValue, *gotPropValue)
 	propExists, propErr := txtMsg.PropertyExists(propName)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists) // now exists
@@ -293,7 +325,9 @@ func TestPropertyClearProperties(t *testing.T) {
 
 	clearErr := txtMsg.ClearProperties()
 	assert.Nil(t, clearErr)
-	assert.Nil(t, txtMsg.GetStringProperty(propName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 	propExists, propErr = txtMsg.PropertyExists(propName)
 	assert.Nil(t, propErr)
 	assert.False(t, propExists)
@@ -308,10 +342,14 @@ func TestPropertyClearProperties(t *testing.T) {
 	// Set multiple properties
 	retErr = txtMsg.SetStringProperty(propName, &propValue)
 	assert.Nil(t, retErr)
-	assert.Equal(t, propValue, *txtMsg.GetStringProperty(propName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, propValue, *gotPropValue)
 	retErr = txtMsg.SetStringProperty(propName2, &propValue2)
 	assert.Nil(t, retErr)
-	assert.Equal(t, propValue2, *txtMsg.GetStringProperty(propName2))
+	gotPropValue, propErr = txtMsg.GetStringProperty(propName2)
+	assert.Nil(t, propErr)
+	assert.Equal(t, propValue2, *gotPropValue)
 	propExists, propErr = txtMsg.PropertyExists(propName2)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists) // now exists
@@ -329,7 +367,9 @@ func TestPropertyClearProperties(t *testing.T) {
 	unsetPropValue := "someValueThatWillBeOverwritten"
 	retErr = txtMsg.SetStringProperty(unsetPropName, &unsetPropValue)
 	assert.Nil(t, retErr)
-	assert.Equal(t, unsetPropValue, *txtMsg.GetStringProperty(unsetPropName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(unsetPropName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, unsetPropValue, *gotPropValue)
 	propExists, propErr = txtMsg.PropertyExists(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists)
@@ -341,7 +381,9 @@ func TestPropertyClearProperties(t *testing.T) {
 	assert.Equal(t, unsetPropName, allPropNames[2])
 	retErr = txtMsg.SetStringProperty(unsetPropName, nil)
 	assert.Nil(t, retErr)
-	assert.Nil(t, txtMsg.GetStringProperty(unsetPropName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(unsetPropName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 	propExists, propErr = txtMsg.PropertyExists(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.False(t, propExists)
@@ -353,7 +395,9 @@ func TestPropertyClearProperties(t *testing.T) {
 
 	clearErr = txtMsg.ClearProperties()
 	assert.Nil(t, clearErr)
-	assert.Nil(t, txtMsg.GetStringProperty(propName))
+	gotPropValue, propErr = txtMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 	propExists, propErr = txtMsg.PropertyExists(propName)
 	assert.Nil(t, propErr)
 	assert.False(t, propExists)
@@ -399,7 +443,9 @@ func TestPropertyClearProperties(t *testing.T) {
 
 	// Properties that are not set should return nil
 	nonExistentPropName := "nonExistentProperty"
-	assert.Nil(t, rcvMsg.GetStringProperty(nonExistentPropName))
+	gotPropValue, propErr = rcvMsg.GetStringProperty(nonExistentPropName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 	propExists, propErr = rcvMsg.PropertyExists(nonExistentPropName)
 	assert.Nil(t, propErr)
 	assert.False(t, propExists)
@@ -412,7 +458,9 @@ func TestPropertyClearProperties(t *testing.T) {
 	// Finally try clearing everything on the received message
 	clearErr = rcvMsg.ClearProperties()
 	assert.Nil(t, clearErr)
-	assert.Nil(t, rcvMsg.GetStringProperty(propName))
+	gotPropValue, propErr = rcvMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Nil(t, gotPropValue)
 	propExists, propErr = rcvMsg.PropertyExists(propName)
 	assert.Nil(t, propErr)
 	assert.False(t, propExists)
@@ -471,7 +519,9 @@ func TestStringPropertyTextMessageNilBody(t *testing.T) {
 	}
 
 	// Check property is available on received message.
-	assert.Equal(t, propValue, *rcvMsg.GetStringProperty(propName))
+	gotPropValue, propErr := rcvMsg.GetStringProperty(propName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, propValue, *gotPropValue)
 
 }
 
@@ -535,7 +585,11 @@ func TestStringPropertyTextMessageEmptyBody(t *testing.T) {
 	}
 
 	// Check property is available on received message.
-	assert.Equal(t, propAValue, *rcvMsg.GetStringProperty(propAName))
-	assert.Equal(t, propBValue, *rcvMsg.GetStringProperty(propBName))
+	gotPropValue, propErr := rcvMsg.GetStringProperty(propAName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, propAValue, *gotPropValue)
+	gotPropValue, propErr = rcvMsg.GetStringProperty(propBName)
+	assert.Nil(t, propErr)
+	assert.Equal(t, propBValue, *gotPropValue)
 
 }

--- a/messageproperties_test.go
+++ b/messageproperties_test.go
@@ -18,23 +18,9 @@ import (
 )
 
 /*
- * mq-golang: SetMP, DltMP, InqMP
- * https://github.com/ibm-messaging/mq-golang/blob/95e9b8b09a1fc167747de7d066c49adb86e14dda/ibmmq/mqi.go#L1080
- *
- * mq-golang sample application to set properties
- * https://github.com/ibm-messaging/mq-golang/blob/master/samples/amqsprop.go#L49
- *
- * JMS: SetStringProperty, GetStringProperty,
- * https://github.com/eclipse-ee4j/messaging/blob/master/api/src/main/java/jakarta/jms/Message.java#L1119
- *
- * Property conversion between types
- *
- */
-
-/*
  * Test the creation of a text message with a string property.
  */
-func TestStringPropertyTextMsg(t *testing.T) {
+func TestPropertyStringTextMsg(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
@@ -132,6 +118,13 @@ func TestStringPropertyTextMsg(t *testing.T) {
 	gotPropValue, propErr = rcvMsg.GetStringProperty(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.Nil(t, gotPropValue)
+
+	// Error checking on property names
+	emptyNameValue, emptyNameErr := rcvMsg.GetStringProperty("")
+	assert.NotNil(t, emptyNameErr)
+	assert.Equal(t, "2513", emptyNameErr.GetErrorCode())
+	assert.Equal(t, "MQRC_PROPERTY_NAME_LENGTH_ERR", emptyNameErr.GetReason())
+	assert.Nil(t, emptyNameValue)
 
 }
 
@@ -475,7 +468,7 @@ func TestPropertyClearProperties(t *testing.T) {
 /*
  * Test send and receive of a text message with a string property and no content.
  */
-func TestStringPropertyTextMessageNilBody(t *testing.T) {
+func TestPropertyStringTextMessageNilBody(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
@@ -532,7 +525,7 @@ func TestStringPropertyTextMessageNilBody(t *testing.T) {
  * body. It's difficult to distinguish nil and empty string so we are expecting
  * that the received message will contain a nil body.
  */
-func TestStringPropertyTextMessageEmptyBody(t *testing.T) {
+func TestPropertyStringTextMessageEmptyBody(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
@@ -599,7 +592,7 @@ func TestStringPropertyTextMessageEmptyBody(t *testing.T) {
 /*
  * Test the creation of a text message with an int property.
  */
-func TestIntProperty(t *testing.T) {
+func TestPropertyInt(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
@@ -689,7 +682,7 @@ func TestIntProperty(t *testing.T) {
 	gotPropValue, propErr = rcvMsg.GetIntProperty(propName)
 	assert.Nil(t, propErr)
 	assert.Equal(t, propValue, gotPropValue)
-	propExists, propErr = txtMsg.PropertyExists(propName)
+	propExists, propErr = rcvMsg.PropertyExists(propName)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists) // now exists
 
@@ -704,16 +697,23 @@ func TestIntProperty(t *testing.T) {
 	gotPropValue, propErr = rcvMsg.GetIntProperty(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.Equal(t, 0, gotPropValue)
-	propExists, propErr = txtMsg.PropertyExists(unsetPropName)
+	propExists, propErr = rcvMsg.PropertyExists(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists) // exists, even though it is set to zero
+
+	// Error checking on property names
+	emptyNameValue, emptyNameErr := rcvMsg.GetStringProperty("")
+	assert.NotNil(t, emptyNameErr)
+	assert.Equal(t, "2513", emptyNameErr.GetErrorCode())
+	assert.Equal(t, "MQRC_PROPERTY_NAME_LENGTH_ERR", emptyNameErr.GetReason())
+	assert.Nil(t, emptyNameValue)
 
 }
 
 /*
  * Test the creation of a text message with a double property.
  */
-func TestDoubleProperty(t *testing.T) {
+func TestPropertyDouble(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
@@ -803,7 +803,7 @@ func TestDoubleProperty(t *testing.T) {
 	gotPropValue, propErr = rcvMsg.GetDoubleProperty(propName)
 	assert.Nil(t, propErr)
 	assert.Equal(t, propValue, gotPropValue)
-	propExists, propErr = txtMsg.PropertyExists(propName)
+	propExists, propErr = rcvMsg.PropertyExists(propName)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists) // now exists
 
@@ -818,16 +818,23 @@ func TestDoubleProperty(t *testing.T) {
 	gotPropValue, propErr = rcvMsg.GetDoubleProperty(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.Equal(t, float64(0), gotPropValue)
-	propExists, propErr = txtMsg.PropertyExists(unsetPropName)
+	propExists, propErr = rcvMsg.PropertyExists(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists) // exists, even though it is set to zero
+
+	// Error checking on property names
+	emptyNameValue, emptyNameErr := rcvMsg.GetStringProperty("")
+	assert.NotNil(t, emptyNameErr)
+	assert.Equal(t, "2513", emptyNameErr.GetErrorCode())
+	assert.Equal(t, "MQRC_PROPERTY_NAME_LENGTH_ERR", emptyNameErr.GetReason())
+	assert.Nil(t, emptyNameValue)
 
 }
 
 /*
  * Test the creation of a text message with a boolean property.
  */
-func TestBooleanProperty(t *testing.T) {
+func TestPropertyBoolean(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
@@ -917,7 +924,7 @@ func TestBooleanProperty(t *testing.T) {
 	gotPropValue, propErr = rcvMsg.GetBooleanProperty(propName)
 	assert.Nil(t, propErr)
 	assert.Equal(t, propValue, gotPropValue)
-	propExists, propErr = txtMsg.PropertyExists(propName)
+	propExists, propErr = rcvMsg.PropertyExists(propName)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists) // now exists
 
@@ -932,9 +939,16 @@ func TestBooleanProperty(t *testing.T) {
 	gotPropValue, propErr = rcvMsg.GetBooleanProperty(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.Equal(t, false, gotPropValue)
-	propExists, propErr = txtMsg.PropertyExists(unsetPropName)
+	propExists, propErr = rcvMsg.PropertyExists(unsetPropName)
 	assert.Nil(t, propErr)
 	assert.True(t, propExists) // exists, even though it is set to zero
+
+	// Error checking on property names
+	emptyNameValue, emptyNameErr := rcvMsg.GetStringProperty("")
+	assert.NotNil(t, emptyNameErr)
+	assert.Equal(t, "2513", emptyNameErr.GetErrorCode())
+	assert.Equal(t, "MQRC_PROPERTY_NAME_LENGTH_ERR", emptyNameErr.GetReason())
+	assert.Nil(t, emptyNameValue)
 
 }
 
@@ -1092,7 +1106,7 @@ func TestPropertyBytesMsg(t *testing.T) {
 /*
  * Test the conversion between string message properties and other data types.
  */
-func TestPropertyTypesStringConversion(t *testing.T) {
+func TestPropertyConversionString(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
@@ -1283,7 +1297,7 @@ func TestPropertyTypesStringConversion(t *testing.T) {
 /*
  * Test the conversion between different int message properties and other data types.
  */
-func TestPropertyTypesIntConversion(t *testing.T) {
+func TestPropertyConversionInt(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
@@ -1421,7 +1435,7 @@ func TestPropertyTypesIntConversion(t *testing.T) {
 /*
  * Test the conversion between different int message properties and other data types.
  */
-func TestPropertyTypesBoolConversion(t *testing.T) {
+func TestPropertyConversionBool(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
@@ -1499,7 +1513,7 @@ func TestPropertyTypesBoolConversion(t *testing.T) {
 /*
  * Test the conversion between different int message properties and other data types.
  */
-func TestPropertyTypesDoubleConversion(t *testing.T) {
+func TestPropertyConversionDouble(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()

--- a/messageproperties_test.go
+++ b/messageproperties_test.go
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) IBM Corporation 2021
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package main
+
+import (
+	"testing"
+
+	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
+	"github.com/ibm-messaging/mq-golang-jms20/mqjms"
+	"github.com/stretchr/testify/assert"
+)
+
+/*
+ * mq-golang: SetMP, DltMP, InqMP
+ * https://github.com/ibm-messaging/mq-golang/blob/95e9b8b09a1fc167747de7d066c49adb86e14dda/ibmmq/mqi.go#L1080
+ *
+ * mq-golang sample application to set properties
+ * https://github.com/ibm-messaging/mq-golang/blob/master/samples/amqsprop.go#L49
+ *
+ * JMS: SetStringProperty, GetStringProperty,
+ * https://github.com/eclipse-ee4j/messaging/blob/master/api/src/main/java/jakarta/jms/Message.java#L1119
+ *
+ * JMS: PropertyExists, ClearProperties, GetPropertyNames
+ */
+
+/*
+ * Test the creation of a text message with a string property.
+ */
+func TestStringPropertyTextMsg(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// Create a TextMessage and check that we can populate it
+	msgBody := "RequestMsg"
+	txtMsg := context.CreateTextMessage()
+	txtMsg.SetText(msgBody)
+
+	propName := "myProperty"
+	propValue := "myValue"
+
+	// Test the empty value before the property is set.
+	// TODO - it would be nicer if this was nil rather than empty string, however it
+	//   doesn't look like that is supported by the mq-golang library itself.
+	assert.Equal(t, "", *txtMsg.GetStringProperty(propName))
+
+	// Test the ability to set properties before the message is sent.
+	retErr := txtMsg.SetStringProperty(propName, propValue)
+	assert.Nil(t, retErr)
+	assert.Equal(t, propValue, *txtMsg.GetStringProperty(propName))
+	assert.Equal(t, msgBody, *txtMsg.GetText())
+
+	// Set up objects for send/receive
+	queue := context.CreateQueue("DEV.QUEUE.1")
+	consumer, errCons := context.CreateConsumer(queue)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+	assert.Nil(t, errCons)
+
+	// Now send the message and get it back again, to check that it roundtripped.
+	errSend := context.CreateProducer().SetTimeToLive(10000).Send(queue, txtMsg)
+	assert.Nil(t, errSend)
+
+	rcvMsg, errRvc := consumer.ReceiveNoWait()
+	assert.Nil(t, errRvc)
+	assert.NotNil(t, rcvMsg)
+
+	switch msg := rcvMsg.(type) {
+	case jms20subset.TextMessage:
+		assert.Equal(t, msgBody, *msg.GetText())
+	default:
+		assert.Fail(t, "Got something other than a text message")
+	}
+
+	// Check property is available on received message.
+	assert.Equal(t, propValue, *rcvMsg.GetStringProperty(propName))
+
+}
+
+/*
+ * Test send and receive of a text message with a string property and no content.
+ */
+func TestStringPropertyTextMessageNilBody(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// Create a TextMessage, and check it has nil content.
+	msg := context.CreateTextMessage()
+	assert.Nil(t, msg.GetText())
+
+	propName := "myProperty2"
+	propValue := "myValue2"
+	retErr := msg.SetStringProperty(propName, propValue)
+	assert.Nil(t, retErr)
+
+	// Now send the message and get it back again, to check that it roundtripped.
+	queue := context.CreateQueue("DEV.QUEUE.1")
+	errSend := context.CreateProducer().SetTimeToLive(10000).Send(queue, msg)
+	assert.Nil(t, errSend)
+
+	consumer, errCons := context.CreateConsumer(queue)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+	assert.Nil(t, errCons)
+
+	rcvMsg, errRvc := consumer.ReceiveNoWait()
+	assert.Nil(t, errRvc)
+	assert.NotNil(t, rcvMsg)
+
+	switch msg := rcvMsg.(type) {
+	case jms20subset.TextMessage:
+		assert.Nil(t, msg.GetText())
+	default:
+		assert.Fail(t, "Got something other than a text message")
+	}
+
+	// Check property is available on received message.
+	assert.Equal(t, propValue, *rcvMsg.GetStringProperty(propName))
+
+}
+
+/*
+ * Test the behaviour for send/receive of a text message with an empty string
+ * body. It's difficult to distinguish nil and empty string so we are expecting
+ * that the received message will contain a nil body.
+ */
+func TestStringPropertyTextMessageEmptyBody(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// Create a TextMessage
+	msg := context.CreateTextMessageWithString("")
+	assert.Equal(t, "", *msg.GetText())
+
+	propAName := "myPropertyA"
+	propAValue := "myValueA"
+	retErr := msg.SetStringProperty(propAName, propAValue)
+	assert.Nil(t, retErr)
+
+	propBName := "myPropertyB"
+	propBValue := "myValueB"
+	retErr = msg.SetStringProperty(propBName, propBValue)
+	assert.Nil(t, retErr)
+
+	// Now send the message and get it back again.
+	queue := context.CreateQueue("DEV.QUEUE.1")
+	errSend := context.CreateProducer().Send(queue, msg)
+	assert.Nil(t, errSend)
+
+	consumer, errCons := context.CreateConsumer(queue)
+	assert.Nil(t, errCons)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+
+	rcvMsg, errRvc := consumer.ReceiveNoWait()
+	assert.Nil(t, errRvc)
+	assert.NotNil(t, rcvMsg)
+
+	switch msg := rcvMsg.(type) {
+	case jms20subset.TextMessage:
+
+		// It's difficult to distinguish between empty string and no string (nil)
+		// so we settle for giving back a nil, so that messages containing empty
+		// string are equivalent to messages containing no string at all.
+		assert.Nil(t, msg.GetText())
+	default:
+		assert.Fail(t, "Got something other than a text message")
+	}
+
+	// Check property is available on received message.
+	assert.Equal(t, propAValue, *rcvMsg.GetStringProperty(propAName))
+	assert.Equal(t, propBValue, *rcvMsg.GetStringProperty(propBName))
+
+}

--- a/messageproperties_test.go
+++ b/messageproperties_test.go
@@ -27,10 +27,6 @@ import (
  * JMS: SetStringProperty, GetStringProperty,
  * https://github.com/eclipse-ee4j/messaging/blob/master/api/src/main/java/jakarta/jms/Message.java#L1119
  *
- * JMS: PropertyExists, ClearProperties, GetPropertyNames
- *         boolean propertyExists(String name) throws JMSException;
- *         void clearProperties() throws JMSException;
- *         Enumeration getPropertyNames() throws JMSException;
  */
 
 /*

--- a/messageproperties_test.go
+++ b/messageproperties_test.go
@@ -1417,3 +1417,246 @@ func TestPropertyTypesIntConversion(t *testing.T) {
 	assert.Equal(t, float64(0), gotDoubleUnsetPropValue)
 
 }
+
+/*
+ * Test the conversion between different int message properties and other data types.
+ */
+func TestPropertyTypesBoolConversion(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	msg := context.CreateTextMessage()
+
+	// Set up some different int properties
+	truePropName := "intOne"
+	trueValue := true
+	falsePropName := "intZero"
+	falseValue := false
+
+	msg.SetBooleanProperty(truePropName, trueValue)
+	msg.SetBooleanProperty(falsePropName, falseValue)
+
+	// Set up objects for send/receive
+	queue := context.CreateQueue("DEV.QUEUE.1")
+	consumer, errCons := context.CreateConsumer(queue)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+	assert.Nil(t, errCons)
+
+	// Now send the message and get it back again, to check that it roundtripped.
+	errSend := context.CreateProducer().SetTimeToLive(10000).Send(queue, msg)
+	assert.Nil(t, errSend)
+
+	rcvMsg, errRvc := consumer.ReceiveNoWait()
+	assert.Nil(t, errRvc)
+	assert.NotNil(t, rcvMsg)
+
+	// Check bool properties were set correctly
+	gotTrueValue, gotTrueErr := rcvMsg.GetBooleanProperty(truePropName)
+	gotFalseValue, gotFalseErr := rcvMsg.GetBooleanProperty(falsePropName)
+	assert.Nil(t, gotTrueErr)
+	assert.Nil(t, gotFalseErr)
+	assert.Equal(t, trueValue, gotTrueValue)
+	assert.Equal(t, falseValue, gotFalseValue)
+
+	// Convert back as string
+	gotStrTrueValue, gotTrueErr := rcvMsg.GetStringProperty(truePropName)
+	gotStrFalseValue, gotFalseErr := rcvMsg.GetStringProperty(falsePropName)
+	assert.Nil(t, gotTrueErr)
+	assert.Nil(t, gotFalseErr)
+	assert.Equal(t, "true", *gotStrTrueValue)
+	assert.Equal(t, "false", *gotStrFalseValue)
+
+	// Convert back as int
+	gotIntTrueValue, gotTrueErr := rcvMsg.GetIntProperty(truePropName)
+	gotIntFalseValue, gotFalseErr := rcvMsg.GetIntProperty(falsePropName)
+	assert.Nil(t, gotTrueErr)
+	assert.Nil(t, gotFalseErr)
+	assert.Equal(t, 1, gotIntTrueValue)
+	assert.Equal(t, 0, gotIntFalseValue)
+
+	// Convert back as double
+	gotDoubleTrueValue, gotTrueErr := rcvMsg.GetDoubleProperty(truePropName)
+	gotDoubleFalseValue, gotFalseErr := rcvMsg.GetDoubleProperty(falsePropName)
+	assert.Nil(t, gotTrueErr)
+	assert.Nil(t, gotFalseErr)
+	assert.Equal(t, float64(1), gotDoubleTrueValue)
+	assert.Equal(t, float64(0), gotDoubleFalseValue)
+
+}
+
+/*
+ * Test the conversion between different int message properties and other data types.
+ */
+func TestPropertyTypesDoubleConversion(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	assert.Nil(t, cfErr)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	msg := context.CreateTextMessage()
+
+	unsetPropName := "thisPropertyIsNotSet"
+
+	// Set up some different int properties
+	doubleOnePropName := "intOne"
+	doubleOneValue := float64(1)
+	doubleZeroPropName := "intZero"
+	doubleZeroValue := float64(0)
+	doubleMinusOnePropName := "intMinusOne"
+	doubleMinusOneValue := float64(-1)
+
+	doubleLargePosPropName := "largePositive"
+	doubleLargePosValue := float64(48632675)
+	doubleLargeNegPropName := "largeNegative"
+	doubleLargeNegValue := float64(-3789753467)
+
+	doubleLargeDecimalPropName := "largePositiveDecimal"
+	doubleLargeDecimalValue := float64(3867493.68473625)
+	doubleLargeNegativeDecimalPropName := "largeNegativeDecimal"
+	doubleLargeNegativeDecimalValue := float64(-87654335674.383656)
+
+	msg.SetDoubleProperty(doubleOnePropName, doubleOneValue)
+	msg.SetDoubleProperty(doubleZeroPropName, doubleZeroValue)
+	msg.SetDoubleProperty(doubleMinusOnePropName, doubleMinusOneValue)
+	msg.SetDoubleProperty(doubleLargePosPropName, doubleLargePosValue)
+	msg.SetDoubleProperty(doubleLargeNegPropName, doubleLargeNegValue)
+	msg.SetDoubleProperty(doubleLargeDecimalPropName, doubleLargeDecimalValue)
+	msg.SetDoubleProperty(doubleLargeNegativeDecimalPropName, doubleLargeNegativeDecimalValue)
+
+	// Set up objects for send/receive
+	queue := context.CreateQueue("DEV.QUEUE.1")
+	consumer, errCons := context.CreateConsumer(queue)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+	assert.Nil(t, errCons)
+
+	// Now send the message and get it back again, to check that it roundtripped.
+	errSend := context.CreateProducer().SetTimeToLive(10000).Send(queue, msg)
+	assert.Nil(t, errSend)
+
+	rcvMsg, errRvc := consumer.ReceiveNoWait()
+	assert.Nil(t, errRvc)
+	assert.NotNil(t, rcvMsg)
+
+	// Check double properties were set correctly
+	gotDoubleOneValue, gotOneErr := rcvMsg.GetDoubleProperty(doubleOnePropName)
+	gotDoubleZeroValue, gotZeroErr := rcvMsg.GetDoubleProperty(doubleZeroPropName)
+	gotDoubleMinusOneValue, gotMinusOneErr := rcvMsg.GetDoubleProperty(doubleMinusOnePropName)
+	gotDoubleLargePosValue, gotLargePosErr := rcvMsg.GetDoubleProperty(doubleLargePosPropName)
+	gotDoubleLargeNegValue, gotLargeNegErr := rcvMsg.GetDoubleProperty(doubleLargeNegPropName)
+	gotDoubleLargePosDecimalValue, gotLargeDecPosErr := rcvMsg.GetDoubleProperty(doubleLargeDecimalPropName)
+	gotDoubleLargeNegDecimalValue, gotLargeDecNegErr := rcvMsg.GetDoubleProperty(doubleLargeNegativeDecimalPropName)
+	gotDoubleUnsetPropValue, gotUnsetErr := rcvMsg.GetDoubleProperty(unsetPropName)
+	assert.Nil(t, gotOneErr)
+	assert.Nil(t, gotZeroErr)
+	assert.Nil(t, gotMinusOneErr)
+	assert.Nil(t, gotLargePosErr)
+	assert.Nil(t, gotLargeNegErr)
+	assert.Nil(t, gotLargeDecPosErr)
+	assert.Nil(t, gotLargeDecNegErr)
+	assert.Nil(t, gotUnsetErr)
+	assert.Equal(t, float64(1), gotDoubleOneValue)
+	assert.Equal(t, float64(0), gotDoubleZeroValue)
+	assert.Equal(t, float64(-1), gotDoubleMinusOneValue)
+	assert.Equal(t, float64(48632675), gotDoubleLargePosValue)
+	assert.Equal(t, float64(-3789753467), gotDoubleLargeNegValue)
+	assert.Equal(t, float64(3867493.68473625), gotDoubleLargePosDecimalValue)
+	assert.Equal(t, float64(-87654335674.383656), gotDoubleLargeNegDecimalValue)
+	assert.Equal(t, float64(0), gotDoubleUnsetPropValue)
+
+	// Convert back as int
+	gotIntOneValue, gotOneErr := rcvMsg.GetIntProperty(doubleOnePropName)
+	gotIntZeroValue, gotZeroErr := rcvMsg.GetIntProperty(doubleZeroPropName)
+	gotIntMinusOneValue, gotMinusOneErr := rcvMsg.GetIntProperty(doubleMinusOnePropName)
+	gotIntLargePosValue, gotLargePosErr := rcvMsg.GetIntProperty(doubleLargePosPropName)
+	gotIntLargeNegValue, gotLargeNegErr := rcvMsg.GetIntProperty(doubleLargeNegPropName)
+	gotIntLargePosDecimalValue, gotLargeDecPosErr := rcvMsg.GetIntProperty(doubleLargeDecimalPropName)
+	gotIntLargeNegDecimalValue, gotLargeDecNegErr := rcvMsg.GetIntProperty(doubleLargeNegativeDecimalPropName)
+	gotIntUnsetPropValue, gotUnsetErr := rcvMsg.GetIntProperty(unsetPropName)
+	assert.Nil(t, gotOneErr)
+	assert.Nil(t, gotZeroErr)
+	assert.Nil(t, gotMinusOneErr)
+	assert.Nil(t, gotLargePosErr)
+	assert.Nil(t, gotLargeNegErr)
+	assert.Nil(t, gotLargeDecPosErr)
+	assert.Nil(t, gotLargeDecNegErr)
+	assert.Nil(t, gotUnsetErr)
+	assert.Equal(t, 1, gotIntOneValue)
+	assert.Equal(t, 0, gotIntZeroValue)
+	assert.Equal(t, -1, gotIntMinusOneValue)
+	assert.Equal(t, 48632675, gotIntLargePosValue)
+	assert.Equal(t, -3789753467, gotIntLargeNegValue)
+	assert.Equal(t, 3867494, gotIntLargePosDecimalValue)
+	assert.Equal(t, -87654335674, gotIntLargeNegDecimalValue)
+	assert.Equal(t, 0, gotIntUnsetPropValue)
+
+	// Convert back as string
+	gotStrOneValue, gotOneErr := rcvMsg.GetStringProperty(doubleOnePropName)
+	gotStrZeroValue, gotZeroErr := rcvMsg.GetStringProperty(doubleZeroPropName)
+	gotStrMinusOneValue, gotMinusOneErr := rcvMsg.GetStringProperty(doubleMinusOnePropName)
+	gotStrLargePosValue, gotLargePosErr := rcvMsg.GetStringProperty(doubleLargePosPropName)
+	gotStrLargeNegValue, gotLargeNegErr := rcvMsg.GetStringProperty(doubleLargeNegPropName)
+	gotStrLargePosDecimalValue, gotLargeDecPosErr := rcvMsg.GetStringProperty(doubleLargeDecimalPropName)
+	gotStrLargeNegDecimalValue, gotLargeDecNegErr := rcvMsg.GetStringProperty(doubleLargeNegativeDecimalPropName)
+	assert.Nil(t, gotOneErr)
+	assert.Nil(t, gotZeroErr)
+	assert.Nil(t, gotMinusOneErr)
+	assert.Nil(t, gotLargePosErr)
+	assert.Nil(t, gotLargeNegErr)
+	assert.Nil(t, gotLargeDecPosErr)
+	assert.Nil(t, gotLargeDecNegErr)
+	assert.Nil(t, gotUnsetErr)
+	assert.Equal(t, "1", *gotStrOneValue)
+	assert.Equal(t, "0", *gotStrZeroValue)
+	assert.Equal(t, "-1", *gotStrMinusOneValue)
+	assert.Equal(t, "4.8632675e+07", *gotStrLargePosValue)
+	assert.Equal(t, "-3.789753467e+09", *gotStrLargeNegValue)
+	assert.Equal(t, "3.86749368473625e+06", *gotStrLargePosDecimalValue)
+	assert.Equal(t, "-8.765433567438365e+10", *gotStrLargeNegDecimalValue)
+
+	// Convert back as bool
+	gotBoolOneValue, gotOneErr := rcvMsg.GetBooleanProperty(doubleOnePropName)
+	gotBoolZeroValue, gotZeroErr := rcvMsg.GetBooleanProperty(doubleZeroPropName)
+	gotBoolMinusOneValue, gotMinusOneErr := rcvMsg.GetBooleanProperty(doubleMinusOnePropName)
+	gotBoolLargePosValue, gotLargePosErr := rcvMsg.GetBooleanProperty(doubleLargePosPropName)
+	gotBoolLargeNegValue, gotLargeNegErr := rcvMsg.GetBooleanProperty(doubleLargeNegPropName)
+	gotBoolLargePosDecimalValue, gotLargeDecPosErr := rcvMsg.GetBooleanProperty(doubleLargeDecimalPropName)
+	gotBoolLargeNegDecimalValue, gotLargeDecNegErr := rcvMsg.GetBooleanProperty(doubleLargeNegativeDecimalPropName)
+	assert.Nil(t, gotOneErr)
+	assert.Nil(t, gotZeroErr)
+	assert.Nil(t, gotMinusOneErr)
+	assert.Nil(t, gotLargePosErr)
+	assert.Nil(t, gotLargeNegErr)
+	assert.Nil(t, gotLargeDecPosErr)
+	assert.Nil(t, gotLargeDecNegErr)
+	assert.Nil(t, gotUnsetErr)
+	assert.Equal(t, true, gotBoolOneValue)
+	assert.Equal(t, false, gotBoolZeroValue)
+	assert.Equal(t, false, gotBoolMinusOneValue)
+	assert.Equal(t, false, gotBoolLargePosValue)
+	assert.Equal(t, false, gotBoolLargeNegValue)
+	assert.Equal(t, false, gotBoolLargePosDecimalValue)
+	assert.Equal(t, false, gotBoolLargeNegDecimalValue)
+
+}

--- a/mqjms/ContextImpl.go
+++ b/mqjms/ContextImpl.go
@@ -10,6 +10,7 @@
 package mqjms
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/ibm-messaging/mq-golang-jms20/jms20subset"
@@ -130,9 +131,15 @@ func (ctx ContextImpl) CreateTextMessage() jms20subset.TextMessage {
 // store and retrieve message properties.
 func createMsgHandle(qMgr ibmmq.MQQueueManager) ibmmq.MQMessageHandle {
 
-	// TODO - error handling on CrtMH
 	cmho := ibmmq.NewMQCMHO()
-	thisMsgHandle, _ := qMgr.CrtMH(cmho)
+	thisMsgHandle, err := qMgr.CrtMH(cmho)
+
+	if err != nil {
+		// No easy way to pass this error back to the application without
+		// changing the function signature, which could break existing
+		// applications.
+		fmt.Println(err)
+	}
 
 	return thisMsgHandle
 

--- a/mqjms/ContextImpl.go
+++ b/mqjms/ContextImpl.go
@@ -114,27 +114,71 @@ func (ctx ContextImpl) CreateConsumerWithSelector(dest jms20subset.Destination, 
 
 // CreateTextMessage is a JMS standard mechanism for creating a TextMessage.
 func (ctx ContextImpl) CreateTextMessage() jms20subset.TextMessage {
-	return &TextMessageImpl{}
+
+	var bodyStr *string
+	thisMsgHandle := createMsgHandle(ctx.qMgr)
+
+	return &TextMessageImpl{
+		bodyStr: bodyStr,
+		MessageImpl: MessageImpl{
+			msgHandle: &thisMsgHandle,
+		},
+	}
+}
+
+// createMsgHandle creates a new message handle object that can be used to
+// store and retrieve message properties.
+func createMsgHandle(qMgr ibmmq.MQQueueManager) ibmmq.MQMessageHandle {
+
+	// TODO - error handling on CrtMH
+	cmho := ibmmq.NewMQCMHO()
+	thisMsgHandle, _ := qMgr.CrtMH(cmho)
+
+	return thisMsgHandle
+
 }
 
 // CreateTextMessageWithString is a JMS standard mechanism for creating a TextMessage
 // and initialise it with the chosen text string.
 func (ctx ContextImpl) CreateTextMessageWithString(txt string) jms20subset.TextMessage {
-	msg := TextMessageImpl{}
-	msg.SetText(txt)
-	return &msg
+
+	thisMsgHandle := createMsgHandle(ctx.qMgr)
+
+	msg := &TextMessageImpl{
+		bodyStr: &txt,
+		MessageImpl: MessageImpl{
+			msgHandle: &thisMsgHandle,
+		},
+	}
+
+	return msg
 }
 
 // CreateBytesMessage is a JMS standard mechanism for creating a BytesMessage.
 func (ctx ContextImpl) CreateBytesMessage() jms20subset.BytesMessage {
-	return &BytesMessageImpl{}
+
+	var thisBodyBytes *[]byte
+	thisMsgHandle := createMsgHandle(ctx.qMgr)
+
+	return &BytesMessageImpl{
+		bodyBytes: thisBodyBytes,
+		MessageImpl: MessageImpl{
+			msgHandle: &thisMsgHandle,
+		},
+	}
 }
 
 // CreateBytesMessageWithBytes is a JMS standard mechanism for creating a BytesMessage.
 func (ctx ContextImpl) CreateBytesMessageWithBytes(bytes []byte) jms20subset.BytesMessage {
-	msg := BytesMessageImpl{}
-	msg.WriteBytes(bytes)
-	return &msg
+
+	thisMsgHandle := createMsgHandle(ctx.qMgr)
+
+	return &BytesMessageImpl{
+		bodyBytes: &bytes,
+		MessageImpl: MessageImpl{
+			msgHandle: &thisMsgHandle,
+		},
+	}
 }
 
 // Commit confirms all messages that were sent under this transaction.

--- a/mqjms/MessageImpl.go
+++ b/mqjms/MessageImpl.go
@@ -337,6 +337,10 @@ func (msg *MessageImpl) GetStringProperty(name string) (*string, jms20subset.JMS
 				retErr = jms20subset.CreateJMSException(MessageImpl_PROPERTY_CONVERT_FAILED_REASON,
 					MessageImpl_PROPERTY_CONVERT_FAILED_CODE, parseErr)
 			}
+		case bool:
+			valueStr = strconv.FormatBool(valueTyped)
+		case float64:
+			valueStr = fmt.Sprintf("%g", valueTyped)
 		default:
 			// TODO - other conversions
 		}
@@ -400,6 +404,17 @@ func (msg *MessageImpl) GetIntProperty(name string) (int, jms20subset.JMSExcepti
 			valueRet = int(valueTyped)
 		case string:
 			valueRet, parseErr = strconv.Atoi(valueTyped)
+			if parseErr != nil {
+				retErr = jms20subset.CreateJMSException(MessageImpl_PROPERTY_CONVERT_FAILED_REASON,
+					MessageImpl_PROPERTY_CONVERT_FAILED_CODE, parseErr)
+			}
+		case bool:
+			if valueTyped {
+				valueRet = 1
+			}
+		case float64:
+			s := fmt.Sprintf("%.0f", valueTyped)
+			valueRet, parseErr = strconv.Atoi(s)
 			if parseErr != nil {
 				retErr = jms20subset.CreateJMSException(MessageImpl_PROPERTY_CONVERT_FAILED_REASON,
 					MessageImpl_PROPERTY_CONVERT_FAILED_CODE, parseErr)
@@ -474,6 +489,10 @@ func (msg *MessageImpl) GetDoubleProperty(name string) (float64, jms20subset.JMS
 			}
 		case int64:
 			valueRet = float64(valueTyped)
+		case bool:
+			if valueTyped {
+				valueRet = 1
+			}
 		default:
 			// TODO - other conversions
 			//fmt.Println("Other type", value, reflect.TypeOf(value))
@@ -544,6 +563,11 @@ func (msg *MessageImpl) GetBooleanProperty(name string) (bool, jms20subset.JMSEx
 			}
 		case int64:
 			// Conversion from int to bool is true iff n=1
+			if valueTyped == 1 {
+				valueRet = true
+			}
+		case float64:
+			// Conversion from float64 to bool is true iff n=1
 			if valueTyped == 1 {
 				valueRet = true
 			}

--- a/mqjms/MessageImpl.go
+++ b/mqjms/MessageImpl.go
@@ -325,9 +325,18 @@ func (msg *MessageImpl) GetStringProperty(name string) (*string, jms20subset.JMS
 	_, value, err := msg.msgHandle.InqMP(impo, pd, name)
 
 	if err == nil {
+
+		var parseErr error
+
 		switch valueTyped := value.(type) {
 		case string:
 			valueStr = valueTyped
+		case int64:
+			valueStr = strconv.FormatInt(valueTyped, 10)
+			if parseErr != nil {
+				retErr = jms20subset.CreateJMSException(MessageImpl_PROPERTY_CONVERT_FAILED_REASON,
+					MessageImpl_PROPERTY_CONVERT_FAILED_CODE, parseErr)
+			}
 		default:
 			// TODO - other conversions
 		}
@@ -463,6 +472,8 @@ func (msg *MessageImpl) GetDoubleProperty(name string) (float64, jms20subset.JMS
 				retErr = jms20subset.CreateJMSException(MessageImpl_PROPERTY_CONVERT_FAILED_REASON,
 					MessageImpl_PROPERTY_CONVERT_FAILED_CODE, parseErr)
 			}
+		case int64:
+			valueRet = float64(valueTyped)
 		default:
 			// TODO - other conversions
 			//fmt.Println("Other type", value, reflect.TypeOf(value))
@@ -530,6 +541,11 @@ func (msg *MessageImpl) GetBooleanProperty(name string) (bool, jms20subset.JMSEx
 			if parseErr != nil {
 				retErr = jms20subset.CreateJMSException(MessageImpl_PROPERTY_CONVERT_FAILED_REASON,
 					MessageImpl_PROPERTY_CONVERT_FAILED_CODE, parseErr)
+			}
+		case int64:
+			// Conversion from int to bool is true iff n=1
+			if valueTyped == 1 {
+				valueRet = true
 			}
 		default:
 			// TODO - other conversions

--- a/mqjms/MessageImpl.go
+++ b/mqjms/MessageImpl.go
@@ -274,7 +274,10 @@ func (msg *MessageImpl) GetApplName() string {
 	return applName
 }
 
-// TODO documentation
+// SetStringProperty enables an application to set a string-type message property.
+//
+// value is *string which allows a nil value to be specified, to unset an individual
+// property.
 func (msg *MessageImpl) SetStringProperty(name string, value *string) jms20subset.JMSException {
 	var retErr jms20subset.JMSException
 
@@ -306,7 +309,8 @@ func (msg *MessageImpl) SetStringProperty(name string, value *string) jms20subse
 	return retErr
 }
 
-// TODO documentation
+// GetStringProperty returns the string value of a named message property.
+// Returns nil if the named property is not set.
 func (msg *MessageImpl) GetStringProperty(name string) *string {
 
 	var valueStr string
@@ -337,26 +341,28 @@ func (msg *MessageImpl) GetStringProperty(name string) *string {
 	return &valueStr
 }
 
-// TODO documentation
+// PropertyExists returns true if the named message property exists on this message.
 func (msg *MessageImpl) PropertyExists(name string) (bool, jms20subset.JMSException) {
 
-	found, _, retErr := msg.getPropertyInternal(name)
+	found, _, retErr := msg.getPropertiesInternal(name)
 	return found, retErr
 
 }
 
-// TODO documentation
+// GetPropertyNames returns a slice of strings containing the name of every message
+// property on this message.
+// Returns a zero length slice if no message properties are defined.
 func (msg *MessageImpl) GetPropertyNames() ([]string, jms20subset.JMSException) {
 
-	_, propNames, retErr := msg.getPropertyInternal("")
+	_, propNames, retErr := msg.getPropertiesInternal("")
 	return propNames, retErr
 }
 
-// TODO documentation
-// Two modes of operation;
-//   - supply non-empty name parameter to check whether that property exists
-//   - supply empty name parameter to get a []string of all property names
-func (msg *MessageImpl) getPropertyInternal(name string) (bool, []string, jms20subset.JMSException) {
+// getPropertiesInternal is an internal helper function that provides a largely
+// identical implication for two application-facing functions;
+// - PropertyExists supplies a non-empty name parameter to check whether that property exists
+// - GetPropertyNames supplies an empty name parameter to get a []string of all property names
+func (msg *MessageImpl) getPropertiesInternal(name string) (bool, []string, jms20subset.JMSException) {
 
 	impo := ibmmq.NewMQIMPO()
 	pd := ibmmq.NewMQPD()
@@ -398,7 +404,7 @@ func (msg *MessageImpl) getPropertyInternal(name string) (bool, []string, jms20s
 	return false, propNames, nil
 }
 
-// TODO documentation
+// ClearProperties removes all message properties from this message.
 func (msg *MessageImpl) ClearProperties() jms20subset.JMSException {
 
 	// Get the list of all property names, as we have to delete

--- a/mqjms/MessageImpl.go
+++ b/mqjms/MessageImpl.go
@@ -311,9 +311,11 @@ func (msg *MessageImpl) SetStringProperty(name string, value *string) jms20subse
 
 // GetStringProperty returns the string value of a named message property.
 // Returns nil if the named property is not set.
-func (msg *MessageImpl) GetStringProperty(name string) *string {
+func (msg *MessageImpl) GetStringProperty(name string) (*string, jms20subset.JMSException) {
 
 	var valueStr string
+	var retErr jms20subset.JMSException
+
 	impo := ibmmq.NewMQIMPO()
 	pd := ibmmq.NewMQPD()
 
@@ -332,13 +334,16 @@ func (msg *MessageImpl) GetStringProperty(name string) *string {
 		if mqret.MQRC == ibmmq.MQRC_PROPERTY_NOT_AVAILABLE {
 			// This indicates that the requested property does not exist.
 			// valueStr will remain with its default value of nil
-			return nil
+			return nil, nil
 		} else {
 			// Err was not nil
-			fmt.Println(err) // TODO - finish error handling
+			rcInt := int(mqret.MQRC)
+			errCode := strconv.Itoa(rcInt)
+			reason := ibmmq.MQItoString("RC", rcInt)
+			retErr = jms20subset.CreateJMSException(reason, errCode, mqret)
 		}
 	}
-	return &valueStr
+	return &valueStr, retErr
 }
 
 // PropertyExists returns true if the named message property exists on this message.

--- a/mqjms/MessageImpl.go
+++ b/mqjms/MessageImpl.go
@@ -21,6 +21,9 @@ import (
 	ibmmq "github.com/ibm-messaging/mq-golang/v5/ibmmq"
 )
 
+const MessageImpl_PROPERTY_CONVERT_FAILED_REASON string = "MQJMS_E_BAD_TYPE"
+const MessageImpl_PROPERTY_CONVERT_FAILED_CODE string = "1055"
+
 // MessageImpl contains the IBM MQ specific attributes that are
 // common to all types of message.
 type MessageImpl struct {
@@ -380,9 +383,18 @@ func (msg *MessageImpl) GetIntProperty(name string) (int, jms20subset.JMSExcepti
 	_, value, err := msg.msgHandle.InqMP(impo, pd, name)
 
 	if err == nil {
+
+		var parseErr error
+
 		switch valueTyped := value.(type) {
 		case int64:
 			valueRet = int(valueTyped)
+		case string:
+			valueRet, parseErr = strconv.Atoi(valueTyped)
+			if parseErr != nil {
+				retErr = jms20subset.CreateJMSException(MessageImpl_PROPERTY_CONVERT_FAILED_REASON,
+					MessageImpl_PROPERTY_CONVERT_FAILED_CODE, parseErr)
+			}
 		default:
 			// TODO - other conversions
 			//fmt.Println("Other type", value, reflect.TypeOf(value))
@@ -439,9 +451,18 @@ func (msg *MessageImpl) GetDoubleProperty(name string) (float64, jms20subset.JMS
 	_, value, err := msg.msgHandle.InqMP(impo, pd, name)
 
 	if err == nil {
+
+		var parseErr error
+
 		switch valueTyped := value.(type) {
 		case float64:
 			valueRet = valueTyped
+		case string:
+			valueRet, parseErr = strconv.ParseFloat(valueTyped, 64)
+			if parseErr != nil {
+				retErr = jms20subset.CreateJMSException(MessageImpl_PROPERTY_CONVERT_FAILED_REASON,
+					MessageImpl_PROPERTY_CONVERT_FAILED_CODE, parseErr)
+			}
 		default:
 			// TODO - other conversions
 			//fmt.Println("Other type", value, reflect.TypeOf(value))
@@ -498,9 +519,18 @@ func (msg *MessageImpl) GetBooleanProperty(name string) (bool, jms20subset.JMSEx
 	_, value, err := msg.msgHandle.InqMP(impo, pd, name)
 
 	if err == nil {
+
+		var parseErr error
+
 		switch valueTyped := value.(type) {
 		case bool:
 			valueRet = valueTyped
+		case string:
+			valueRet, parseErr = strconv.ParseBool(valueTyped)
+			if parseErr != nil {
+				retErr = jms20subset.CreateJMSException(MessageImpl_PROPERTY_CONVERT_FAILED_REASON,
+					MessageImpl_PROPERTY_CONVERT_FAILED_CODE, parseErr)
+			}
 		default:
 			// TODO - other conversions
 			//fmt.Println("Other type", value, reflect.TypeOf(value))

--- a/mqjms/MessageImpl.go
+++ b/mqjms/MessageImpl.go
@@ -346,6 +346,65 @@ func (msg *MessageImpl) GetStringProperty(name string) (*string, jms20subset.JMS
 	return &valueStr, retErr
 }
 
+// SetIntProperty enables an application to set a int-type message property.
+func (msg *MessageImpl) SetIntProperty(name string, value int) jms20subset.JMSException {
+	var retErr jms20subset.JMSException
+
+	var linkedErr error
+
+	smpo := ibmmq.NewMQSMPO()
+	pd := ibmmq.NewMQPD()
+
+	linkedErr = msg.msgHandle.SetMP(smpo, name, pd, value)
+
+	if linkedErr != nil {
+		rcInt := int(linkedErr.(*ibmmq.MQReturn).MQRC)
+		errCode := strconv.Itoa(rcInt)
+		reason := ibmmq.MQItoString("RC", rcInt)
+		retErr = jms20subset.CreateJMSException(reason, errCode, linkedErr)
+	}
+
+	return retErr
+}
+
+// GetIntProperty returns the int value of a named message property.
+// Returns 0 if the named property is not set.
+func (msg *MessageImpl) GetIntProperty(name string) (int, jms20subset.JMSException) {
+
+	var valueRet int
+	var retErr jms20subset.JMSException
+
+	impo := ibmmq.NewMQIMPO()
+	pd := ibmmq.NewMQPD()
+
+	_, value, err := msg.msgHandle.InqMP(impo, pd, name)
+
+	if err == nil {
+		switch valueTyped := value.(type) {
+		case int64:
+			valueRet = int(valueTyped)
+		default:
+			// TODO - other conversions
+			//fmt.Println("Other type", value, reflect.TypeOf(value))
+		}
+	} else {
+
+		mqret := err.(*ibmmq.MQReturn)
+		if mqret.MQRC == ibmmq.MQRC_PROPERTY_NOT_AVAILABLE {
+			// This indicates that the requested property does not exist.
+			// valueRet will remain with its default value of nil
+			return 0, nil
+		} else {
+			// Err was not nil
+			rcInt := int(mqret.MQRC)
+			errCode := strconv.Itoa(rcInt)
+			reason := ibmmq.MQItoString("RC", rcInt)
+			retErr = jms20subset.CreateJMSException(reason, errCode, mqret)
+		}
+	}
+	return valueRet, retErr
+}
+
 // PropertyExists returns true if the named message property exists on this message.
 func (msg *MessageImpl) PropertyExists(name string) (bool, jms20subset.JMSException) {
 

--- a/mqjms/ProducerImpl.go
+++ b/mqjms/ProducerImpl.go
@@ -103,6 +103,9 @@ func (producer ProducerImpl) Send(dest jms20subset.Destination, msg jms20subset.
 			putmqmd = typedMsg.mqmd
 		}
 
+		// Pass up the handle containing the message properties
+		pmo.OriginalMsgHandle = *typedMsg.msgHandle
+
 		// Store the Put MQMD so that we can later retrieve "out" fields like MsgId
 		typedMsg.mqmd = putmqmd
 
@@ -120,6 +123,9 @@ func (producer ProducerImpl) Send(dest jms20subset.Destination, msg jms20subset.
 		if typedMsg.mqmd != nil {
 			putmqmd = typedMsg.mqmd
 		}
+
+		// Pass up the handle containing the message properties
+		pmo.OriginalMsgHandle = *typedMsg.msgHandle
 
 		// Store the Put MQMD so that we can later retrieve "out" fields like MsgId
 		typedMsg.mqmd = putmqmd

--- a/next-features.txt
+++ b/next-features.txt
@@ -8,7 +8,6 @@ Not currently implemented:
 - MessageListener
 - SendToQmgr, ReplyToQmgr
 - Topics (pub/sub)
-- Message Properties etc
 - Temporary destinations
 - Priority
 - Configurable option to auto-set the receive buffer length if the default 32kb is exceeded (less efficient that setting up front)


### PR DESCRIPTION
Implements message property support for types;
- string
- int
- bool
- double

plus helper methods PropertyExists, ClearProperties and GetPropertyNames.

see [Message.go](./jms20subset/Message.go) for function definitions, and [messageproperties_test.go](messageproperties_test.go) for examples.
