### PR TITLE
Update Dockerfile to MQ 9.3.0.0 - #59

### DIFF
--- a/openshift-app-sample/Dockerfile
+++ b/openshift-app-sample/Dockerfile
@@ -5,7 +5,7 @@
  # Location of the downloadable MQ client package \
  ENV RDURL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist" \
     RDTAR="IBM-MQC-Redist-LinuxX64.tar.gz" \
-    VRMF=9.2.0.1
+    VRMF=9.3.0.0
  # Install the MQ client from the Redistributable package. This also contains the
  # header files we need to compile against. Setup the subset of the package
  # we are going to keep - the genmqpkg.sh script removes unneeded parts


### PR DESCRIPTION
Binaries for MQ 9.2.0.1 have been archived, so setting to 9.3.0.0 which is retained longer.