### PR TITLE
Add support for handling truncated messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ your own error handling or logging.
 * Handle error codes returned by the queue manager - [sample_errorhandling_test.go](sample_errorhandling_test.go)
 * Set the application name (ApplName) on connections - [applname_test.go](applname_test.go)
 * Receive messages over 32kb in size by setting the receive buffer size - [largemessage_test.go](largemessage_test.go)
+* Receive a truncated message body for the case where the body is larger than the allowed buffer size - [largemessage_test.go#301](largemessage_test.go#301)
 * Asynchronous put - [asyncput_test.go](asyncput_test.go)
 * Special header properties such as JMS_IBM_Format - [specialproperties_test.go](specialproperties_test.go)
 

--- a/jms20subset/JMSException.go
+++ b/jms20subset/JMSException.go
@@ -24,9 +24,10 @@ type JMSException interface {
 
 // JMSExceptionImpl is a struct that implements the JMSException interface
 type JMSExceptionImpl struct {
-	reason    string
-	errorCode string
-	linkedErr error
+	reason        string
+	errorCode     string
+	linkedErr     error
+	messageLength int
 }
 
 // GetReason returns the provider-specific reason string describing the error.
@@ -51,6 +52,15 @@ func (ex JMSExceptionImpl) GetLinkedError() error {
 
 }
 
+// GetMessageLength gives the data length that was returned by a Receive (GET) call,
+// for example if the message was truncated, or could not be read because the receive
+// buffer was too small.
+func (ex JMSExceptionImpl) GetMessageLength() int {
+
+	return ex.messageLength
+
+}
+
 // Error allows the JMSExceptionImpl struct to be treated as a Golang error,
 // while also returning a human readable string representation of the error.
 func (ex JMSExceptionImpl) Error() string {
@@ -66,11 +76,17 @@ func (ex JMSExceptionImpl) Error() string {
 
 // CreateJMSException is a helper function for creating a JMSException
 func CreateJMSException(reason string, errorCode string, linkedErr error) JMSException {
+	return CreateJMSExceptionWithExtraParams(reason, errorCode, linkedErr, 0)
+}
+
+// CreateJMSException is a helper function for creating a JMSException
+func CreateJMSExceptionWithExtraParams(reason string, errorCode string, linkedErr error, messageLength int) JMSException {
 
 	ex := JMSExceptionImpl{
-		reason:    reason,
-		errorCode: errorCode,
-		linkedErr: linkedErr,
+		reason:        reason,
+		errorCode:     errorCode,
+		linkedErr:     linkedErr,
+		messageLength: messageLength,
 	}
 
 	return ex

--- a/largemessage_test.go
+++ b/largemessage_test.go
@@ -134,7 +134,7 @@ func TestLargeReceiveStringBodyTextMessage(t *testing.T) {
 
 	// The message is still left on the queue since it failed to be received successfully.
 
-	// Since the buffer size is configured using the ConnectionFactoy we will
+	// Since the buffer size is configured using the ConnectionFactory we will
 	// create a second connection in order to successfully retrieve the message.
 	cf.ReceiveBufferSize = len(txtOver32kb) + 50
 
@@ -292,6 +292,80 @@ func TestLargeReceiveBytesBodyBytesMessage(t *testing.T) {
 	rcvBytes2, errRcv2 := consumer2.ReceiveBytesBodyNoWait()
 	assert.Nil(t, errRcv2)
 	assert.Equal(t, &bytesOver32kb, rcvBytes2)
+
+}
+
+/*
+ * Test receiving a truncated message, where the body of the message is larger than the receive buffer.
+ */
+func TestTruncatedTextMessage(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	cf.ReceiveBufferSize = 1024
+	// TODO - set parameter to allow receive of truncated message
+	assert.Nil(t, cfErr)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// Get a long text string over 32kb in length
+	txtOver32kb := getStringOver32kb()
+
+	// Create a TextMessage with it
+	msg := context.CreateTextMessageWithString(txtOver32kb)
+
+	// Now send the message and get it back again.
+	queue := context.CreateQueue("DEV.QUEUE.1")
+	errSend := context.CreateProducer().SetTimeToLive(5000).Send(queue, msg)
+	assert.Nil(t, errSend)
+
+	consumer, errCons := context.CreateConsumer(queue) // with 1kb buffer size as applied at the beginning of this test
+	assert.Nil(t, errCons)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+
+	// This will fail because the default buffer size when receiving a
+	// message is 32kb.
+	truncMsg, errRcv := consumer.ReceiveNoWait()
+	assert.NotNil(t, errRcv)
+	assert.Equal(t, "MQRC_TRUNCATED_MSG_ACCEPTED", errRcv.GetReason())
+	assert.Equal(t, "2079", errRcv.GetErrorCode())
+
+	assert.NotNil(t, truncMsg) // We have received the message, but it is truncated.
+
+	switch txtTruncMsg := truncMsg.(type) {
+	case jms20subset.TextMessage:
+		receivedTxt := txtTruncMsg.GetText()
+		assert.Equal(t, cf.ReceiveBufferSize, len(*receivedTxt))
+	default:
+		assert.Fail(t, "Got something other than a text message")
+	}
+
+	// Make sure we tidy up in case the previous part of the test failed.
+	cf.ReceiveBufferSize = len(txtOver32kb) + 50
+
+	context2, ctxErr2 := cf.CreateContext()
+	assert.Nil(t, ctxErr2)
+	if context2 != nil {
+		defer context2.Close()
+	}
+
+	consumer2, errCons2 := context2.CreateConsumer(queue)
+	assert.Nil(t, errCons2)
+	if consumer2 != nil {
+		defer consumer2.Close()
+	}
+
+	rcvMsg2, errRcv2 := consumer2.ReceiveNoWait()
+	assert.Nil(t, errRcv2)
+	assert.NotNil(t, rcvMsg2)
 
 }
 

--- a/largemessage_test.go
+++ b/largemessage_test.go
@@ -62,9 +62,20 @@ func TestLargeTextMessage(t *testing.T) {
 
 	// The message is still left on the queue since it failed to be received successfully.
 
-	// Since the buffer size is configured using the ConnectionFactoy we will
-	// create a second connection in order to successfully retrieve the message.
-	cf.ReceiveBufferSize = len(txtOver32kb) + 50
+	// Use a special attribute of the returned exception to look up what the actual length of the
+	// message is, so that we can correctly increase the buffer size in order to receive the message.
+	switch jmsExc := errRcv.(type) {
+	case jms20subset.JMSExceptionImpl:
+		realMessageLength := jmsExc.GetMessageLength()
+		assert.Equal(t, len(txtOver32kb), realMessageLength) // check it matches the original (long) length
+
+		// Since the buffer size is configured using the ConnectionFactory we will
+		// create a second connection in order to successfully retrieve the message.
+		cf.ReceiveBufferSize = realMessageLength
+
+	default:
+		assert.Fail(t, "Got something other than a JMSExceptionImpl")
+	}
 
 	context2, ctxErr2 := cf.CreateContext()
 	assert.Nil(t, ctxErr2)
@@ -78,7 +89,7 @@ func TestLargeTextMessage(t *testing.T) {
 		defer consumer2.Close()
 	}
 
-	rcvMsg2, errRcv2 := consumer2.ReceiveNoWait()
+	rcvMsg2, errRcv2 := consumer2.ReceiveNoWait() // receive the message using the correct (larger) buffer size
 	assert.Nil(t, errRcv2)
 	assert.NotNil(t, rcvMsg2)
 
@@ -134,9 +145,20 @@ func TestLargeReceiveStringBodyTextMessage(t *testing.T) {
 
 	// The message is still left on the queue since it failed to be received successfully.
 
-	// Since the buffer size is configured using the ConnectionFactory we will
-	// create a second connection in order to successfully retrieve the message.
-	cf.ReceiveBufferSize = len(txtOver32kb) + 50
+	// Use a special attribute of the returned exception to look up what the actual length of the
+	// message is, so that we can correctly increase the buffer size in order to receive the message.
+	switch jmsExc := errRcv.(type) {
+	case jms20subset.JMSExceptionImpl:
+		realMessageLength := jmsExc.GetMessageLength()
+		assert.Equal(t, len(txtOver32kb), realMessageLength) // check it matches the original (long) length
+
+		// Since the buffer size is configured using the ConnectionFactory we will
+		// create a second connection in order to successfully retrieve the message.
+		cf.ReceiveBufferSize = realMessageLength
+
+	default:
+		assert.Fail(t, "Got something other than a JMSExceptionImpl")
+	}
 
 	context2, ctxErr2 := cf.CreateContext()
 	assert.Nil(t, ctxErr2)
@@ -200,9 +222,20 @@ func TestLargeBytesMessage(t *testing.T) {
 
 	// The message is still left on the queue since it failed to be received successfully.
 
-	// Since the buffer size is configured using the ConnectionFactoy we will
-	// create a second connection in order to successfully retrieve the message.
-	cf.ReceiveBufferSize = len(bytesOver32kb) + 50
+	// Use a special attribute of the returned exception to look up what the actual length of the
+	// message is, so that we can correctly increase the buffer size in order to receive the message.
+	switch jmsExc := errRcv.(type) {
+	case jms20subset.JMSExceptionImpl:
+		realMessageLength := jmsExc.GetMessageLength()
+		assert.Equal(t, len(txtOver32kb), realMessageLength) // check it matches the original (long) length
+
+		// Since the buffer size is configured using the ConnectionFactory we will
+		// create a second connection in order to successfully retrieve the message.
+		cf.ReceiveBufferSize = realMessageLength
+
+	default:
+		assert.Fail(t, "Got something other than a JMSExceptionImpl")
+	}
 
 	context2, ctxErr2 := cf.CreateContext()
 	assert.Nil(t, ctxErr2)
@@ -273,9 +306,20 @@ func TestLargeReceiveBytesBodyBytesMessage(t *testing.T) {
 
 	// The message is still left on the queue since it failed to be received successfully.
 
-	// Since the buffer size is configured using the ConnectionFactoy we will
-	// create a second connection in order to successfully retrieve the message.
-	cf.ReceiveBufferSize = len(bytesOver32kb) + 50
+	// Use a special attribute of the returned exception to look up what the actual length of the
+	// message is, so that we can correctly increase the buffer size in order to receive the message.
+	switch jmsExc := errRcv.(type) {
+	case jms20subset.JMSExceptionImpl:
+		realMessageLength := jmsExc.GetMessageLength()
+		assert.Equal(t, len(txtOver32kb), realMessageLength) // check it matches the original (long) length
+
+		// Since the buffer size is configured using the ConnectionFactory we will
+		// create a second connection in order to successfully retrieve the message.
+		cf.ReceiveBufferSize = realMessageLength
+
+	default:
+		assert.Fail(t, "Got something other than a JMSExceptionImpl")
+	}
 
 	context2, ctxErr2 := cf.CreateContext()
 	assert.Nil(t, ctxErr2)
@@ -348,8 +392,21 @@ func TestTruncatedTextMessage(t *testing.T) {
 		assert.Fail(t, "Got something other than a text message")
 	}
 
-	// Make sure we tidy up in case the previous part of the test failed.
-	cf.ReceiveBufferSize = len(txtOver32kb) + 50
+	// Use a special attribute of the returned exception to look up what the actual length of the
+	// message is, so that we can tidy up the message (read successfully) in the event the previous
+	// step failed.
+	switch jmsExc := errRcv.(type) {
+	case jms20subset.JMSExceptionImpl:
+		realMessageLength := jmsExc.GetMessageLength()
+		assert.Equal(t, len(txtOver32kb), realMessageLength) // check it matches the original (long) length
+
+		// Since the buffer size is configured using the ConnectionFactory we will
+		// create a second connection in order to successfully retrieve the message.
+		cf.ReceiveBufferSize = realMessageLength
+
+	default:
+		assert.Fail(t, "Got something other than a JMSExceptionImpl")
+	}
 
 	context2, ctxErr2 := cf.CreateContext()
 	assert.Nil(t, ctxErr2)

--- a/largemessage_test.go
+++ b/largemessage_test.go
@@ -296,14 +296,14 @@ func TestLargeReceiveBytesBodyBytesMessage(t *testing.T) {
 }
 
 /*
- * Test receiving a truncated message, where the body of the message is larger than the receive buffer.
+ * Test receiving a truncated text message, where the body of the message is larger than the receive buffer.
  */
 func TestTruncatedTextMessage(t *testing.T) {
 
 	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
 	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
 	cf.ReceiveBufferSize = 1024
-	// TODO - set parameter to allow receive of truncated message
+	cf.AcceptTruncatedMessage = true
 	assert.Nil(t, cfErr)
 
 	// Creates a connection to the queue manager, using defer to close it automatically
@@ -346,6 +346,80 @@ func TestTruncatedTextMessage(t *testing.T) {
 		assert.Equal(t, cf.ReceiveBufferSize, len(*receivedTxt))
 	default:
 		assert.Fail(t, "Got something other than a text message")
+	}
+
+	// Make sure we tidy up in case the previous part of the test failed.
+	cf.ReceiveBufferSize = len(txtOver32kb) + 50
+
+	context2, ctxErr2 := cf.CreateContext()
+	assert.Nil(t, ctxErr2)
+	if context2 != nil {
+		defer context2.Close()
+	}
+
+	consumer2, errCons2 := context2.CreateConsumer(queue)
+	assert.Nil(t, errCons2)
+	if consumer2 != nil {
+		defer consumer2.Close()
+	}
+
+	// Attempt to receive a message, and don't worry whether it does or not.
+	consumer2.ReceiveNoWait()
+
+}
+
+/*
+ * Test receiving a truncated bytes message, where the body of the message is larger than the receive buffer.
+ */
+func TestTruncatedBytesMessage(t *testing.T) {
+
+	// Loads CF parameters from connection_info.json and applicationApiKey.json in the Downloads directory
+	cf, cfErr := mqjms.CreateConnectionFactoryFromDefaultJSONFiles()
+	cf.ReceiveBufferSize = 1024
+	cf.AcceptTruncatedMessage = true
+	assert.Nil(t, cfErr)
+
+	// Creates a connection to the queue manager, using defer to close it automatically
+	// at the end of the function (if it was created successfully)
+	context, ctxErr := cf.CreateContext()
+	assert.Nil(t, ctxErr)
+	if context != nil {
+		defer context.Close()
+	}
+
+	// Get a long text string over 32kb in length
+	txtOver32kb := getStringOver32kb()
+	bytesOver32kb := []byte(txtOver32kb)
+
+	// Create a TextMessage with it
+	msg := context.CreateBytesMessageWithBytes(bytesOver32kb)
+
+	// Now send the message and get it back again.
+	queue := context.CreateQueue("DEV.QUEUE.1")
+	errSend := context.CreateProducer().SetTimeToLive(5000).Send(queue, msg)
+	assert.Nil(t, errSend)
+
+	consumer, errCons := context.CreateConsumer(queue) // with 1kb buffer size as applied at the beginning of this test
+	assert.Nil(t, errCons)
+	if consumer != nil {
+		defer consumer.Close()
+	}
+
+	// Since we have set the flag to allow a truncated message to be returned, this will pass
+	// but will only return the first 1024 bytes (cf.ReceiveBufferSize) of the message.
+	truncMsg, errRcv := consumer.ReceiveNoWait()
+	assert.NotNil(t, errRcv)
+	assert.Equal(t, "MQRC_TRUNCATED_MSG_ACCEPTED", errRcv.GetReason())
+	assert.Equal(t, "2079", errRcv.GetErrorCode())
+
+	assert.NotNil(t, truncMsg) // We have received the message, but it is truncated.
+
+	switch bytesTruncMsg := truncMsg.(type) {
+	case jms20subset.BytesMessage:
+		receivedBytes := bytesTruncMsg.ReadBytes()
+		assert.Equal(t, cf.ReceiveBufferSize, len(*receivedBytes))
+	default:
+		assert.Fail(t, "Got something other than a bytes message")
 	}
 
 	// Make sure we tidy up in case the previous part of the test failed.

--- a/largemessage_test.go
+++ b/largemessage_test.go
@@ -331,8 +331,8 @@ func TestTruncatedTextMessage(t *testing.T) {
 		defer consumer.Close()
 	}
 
-	// This will fail because the default buffer size when receiving a
-	// message is 32kb.
+	// Since we have set the flag to allow a truncated message to be returned, this will pass
+	// but will only return the first 1024 bytes (cf.ReceiveBufferSize) of the message.
 	truncMsg, errRcv := consumer.ReceiveNoWait()
 	assert.NotNil(t, errRcv)
 	assert.Equal(t, "MQRC_TRUNCATED_MSG_ACCEPTED", errRcv.GetReason())
@@ -363,9 +363,8 @@ func TestTruncatedTextMessage(t *testing.T) {
 		defer consumer2.Close()
 	}
 
-	rcvMsg2, errRcv2 := consumer2.ReceiveNoWait()
-	assert.Nil(t, errRcv2)
-	assert.NotNil(t, rcvMsg2)
+	// Attempt to receive a message, and don't worry whether it does or not.
+	consumer2.ReceiveNoWait()
 
 }
 

--- a/largemessage_test.go
+++ b/largemessage_test.go
@@ -420,8 +420,10 @@ func TestTruncatedTextMessage(t *testing.T) {
 		defer consumer2.Close()
 	}
 
-	// Attempt to receive a message, and don't worry whether it does or not.
-	consumer2.ReceiveNoWait()
+	// If the first part of this text was successful then there should be no message to receive.
+	tidyMsg, tidyErr := consumer2.ReceiveNoWait()
+	assert.Nil(t, tidyErr)
+	assert.Nil(t, tidyMsg)
 
 }
 

--- a/mqjms/ConnectionFactoryImpl.go
+++ b/mqjms/ConnectionFactoryImpl.go
@@ -48,6 +48,9 @@ type ConnectionFactoryImpl struct {
 	// Controls the size of the buffer used when receiving a message (default is 32kb if not set)
 	ReceiveBufferSize int
 
+	// Controls whether a message should be returned if the body will be truncated (because the body is larger than the ReceiveBufferSize)
+	AcceptTruncatedMessage bool
+
 	// SetCheckCount defines the number of messages that will be asynchronously put using
 	// this Context between checks for errors. For example a value of 10 will cause an error
 	// check to be triggered once for every 10 messages.
@@ -155,12 +158,13 @@ func (cf ConnectionFactoryImpl) CreateContextWithSessionMode(sessionMode int, mq
 		// Connection was created successfully, so we wrap the MQI object into
 		// a new ContextImpl and return it to the caller.
 		ctx = ContextImpl{
-			qMgr:              qMgr,
-			ctxLock:           &sync.Mutex{},
-			sessionMode:       sessionMode,
-			receiveBufferSize: cf.ReceiveBufferSize,
-			sendCheckCount:    cf.SendCheckCount,
-			sendCheckCountInc: countInc,
+			qMgr:                   qMgr,
+			ctxLock:                &sync.Mutex{},
+			sessionMode:            sessionMode,
+			receiveBufferSize:      cf.ReceiveBufferSize,
+			acceptTruncatedMessage: cf.AcceptTruncatedMessage,
+			sendCheckCount:         cf.SendCheckCount,
+			sendCheckCountInc:      countInc,
 		}
 
 	}

--- a/mqjms/ConsumerImpl.go
+++ b/mqjms/ConsumerImpl.go
@@ -71,13 +71,13 @@ func (consumer ConsumerImpl) receiveInternal(gmo *ibmmq.MQGMO) (jms20subset.Mess
 
 	getmqmd := ibmmq.NewMQMD()
 
-	myBufferSize := 32768
+	bufferSize := 32768
 
 	if consumer.ctx.receiveBufferSize > 0 {
-		myBufferSize = consumer.ctx.receiveBufferSize
+		bufferSize = consumer.ctx.receiveBufferSize
 	}
 
-	buffer := make([]byte, myBufferSize)
+	buffer := make([]byte, bufferSize)
 
 	// Calculate the syncpoint value
 	syncpointSetting := ibmmq.MQGMO_NO_SYNCPOINT
@@ -88,6 +88,7 @@ func (consumer ConsumerImpl) receiveInternal(gmo *ibmmq.MQGMO) (jms20subset.Mess
 	// Set the GMO (get message options)
 	gmo.Options |= syncpointSetting
 	gmo.Options |= ibmmq.MQGMO_FAIL_IF_QUIESCING
+	gmo.Options |= ibmmq.MQGMO_ACCEPT_TRUNCATED_MSG
 
 	// Include the message properties in the msgHandle
 	gmo.Options |= ibmmq.MQGMO_PROPERTIES_IN_HANDLE
@@ -105,7 +106,24 @@ func (consumer ConsumerImpl) receiveInternal(gmo *ibmmq.MQGMO) (jms20subset.Mess
 	// Use the prepared objects to ask for a message from the queue.
 	datalen, err := consumer.qObject.Get(getmqmd, gmo, buffer)
 
-	if err == nil {
+	// Establish the read length so that it does not exceed the size of the buffer.
+	readLength := datalen
+	if datalen > bufferSize {
+		readLength = bufferSize
+	}
+
+	// Check whether this is a truncated message.
+	isTruncatedMessage := false
+	if err != nil && ((err.(*ibmmq.MQReturn)).MQRC == ibmmq.MQRC_TRUNCATED_MSG_ACCEPTED) {
+		isTruncatedMessage = true
+
+		// In the truncated message case we want to return the warning object as well as the message
+		// so that the application can tell that some of the data is missing.
+		jmsErr = CreateJMSExceptionFromMQReturn(err)
+	}
+
+	// Golden path - typically a message was received without error.
+	if err == nil || isTruncatedMessage {
 
 		// Set a finalizer on the message handle to allow it to be deleted
 		// when it is no longer referenced by an active object, to reduce/prevent
@@ -119,8 +137,8 @@ func (consumer ConsumerImpl) receiveInternal(gmo *ibmmq.MQGMO) (jms20subset.Mess
 
 			var msgBodyStr *string
 
-			if datalen > 0 {
-				strContent := string(buffer[:datalen])
+			if readLength > 0 {
+				strContent := string(buffer[:readLength])
 				msgBodyStr = &strContent
 			}
 
@@ -135,11 +153,11 @@ func (consumer ConsumerImpl) receiveInternal(gmo *ibmmq.MQGMO) (jms20subset.Mess
 
 		} else {
 
-			if datalen == 0 {
+			if readLength == 0 {
 				buffer = []byte{}
 			}
 
-			trimmedBuffer := buffer[0:datalen]
+			trimmedBuffer := buffer[0:readLength]
 
 			// Not a string, so fall back to BytesMessage
 			msg = &BytesMessageImpl{
@@ -172,11 +190,7 @@ func (consumer ConsumerImpl) receiveInternal(gmo *ibmmq.MQGMO) (jms20subset.Mess
 
 			// Parse the details of the error and return it to the caller as
 			// a JMSException
-			rcInt := int(mqret.MQRC)
-			errCode := strconv.Itoa(rcInt)
-			reason := ibmmq.MQItoString("RC", rcInt)
-
-			jmsErr = jms20subset.CreateJMSException(reason, errCode, err)
+			jmsErr = CreateJMSExceptionFromMQReturn(err)
 		}
 
 	}
@@ -416,4 +430,21 @@ func (consumer ConsumerImpl) Close() {
 	}
 
 	return
+}
+
+func CreateJMSExceptionFromMQReturn(mqretError error) jms20subset.JMSException {
+
+	// Assumes this error code was returned from MQ call.
+	mqret := mqretError.(*ibmmq.MQReturn)
+
+	// Parse the details of the error and return it to the caller as
+	// a JMSException
+	rcInt := int(mqret.MQRC)
+	errCode := strconv.Itoa(rcInt)
+	reason := ibmmq.MQItoString("RC", rcInt)
+
+	jmsErr := jms20subset.CreateJMSException(reason, errCode, mqretError)
+
+	return jmsErr
+
 }

--- a/mqjms/ConsumerImpl.go
+++ b/mqjms/ConsumerImpl.go
@@ -88,7 +88,11 @@ func (consumer ConsumerImpl) receiveInternal(gmo *ibmmq.MQGMO) (jms20subset.Mess
 	// Set the GMO (get message options)
 	gmo.Options |= syncpointSetting
 	gmo.Options |= ibmmq.MQGMO_FAIL_IF_QUIESCING
-	gmo.Options |= ibmmq.MQGMO_ACCEPT_TRUNCATED_MSG
+
+	// Allow a truncated message to be returned if the user has requested it (default is to return an error on get)
+	if consumer.ctx.acceptTruncatedMessage {
+		gmo.Options |= ibmmq.MQGMO_ACCEPT_TRUNCATED_MSG
+	}
 
 	// Include the message properties in the msgHandle
 	gmo.Options |= ibmmq.MQGMO_PROPERTIES_IN_HANDLE

--- a/mqjms/ConsumerImpl.go
+++ b/mqjms/ConsumerImpl.go
@@ -123,7 +123,7 @@ func (consumer ConsumerImpl) receiveInternal(gmo *ibmmq.MQGMO) (jms20subset.Mess
 
 		// In the truncated message case we want to return the warning object as well as the message
 		// so that the application can tell that some of the data is missing.
-		jmsErr = CreateJMSExceptionFromMQReturn(err)
+		jmsErr = CreateJMSExceptionFromMQReturn(err, datalen)
 	}
 
 	// Golden path - typically a message was received without error.
@@ -194,7 +194,7 @@ func (consumer ConsumerImpl) receiveInternal(gmo *ibmmq.MQGMO) (jms20subset.Mess
 
 			// Parse the details of the error and return it to the caller as
 			// a JMSException
-			jmsErr = CreateJMSExceptionFromMQReturn(err)
+			jmsErr = CreateJMSExceptionFromMQReturn(err, datalen)
 		}
 
 	}
@@ -436,7 +436,7 @@ func (consumer ConsumerImpl) Close() {
 	return
 }
 
-func CreateJMSExceptionFromMQReturn(mqretError error) jms20subset.JMSException {
+func CreateJMSExceptionFromMQReturn(mqretError error, datalen int) jms20subset.JMSException {
 
 	// Assumes this error code was returned from MQ call.
 	mqret := mqretError.(*ibmmq.MQReturn)
@@ -447,7 +447,7 @@ func CreateJMSExceptionFromMQReturn(mqretError error) jms20subset.JMSException {
 	errCode := strconv.Itoa(rcInt)
 	reason := ibmmq.MQItoString("RC", rcInt)
 
-	jmsErr := jms20subset.CreateJMSException(reason, errCode, mqretError)
+	jmsErr := jms20subset.CreateJMSExceptionWithExtraParams(reason, errCode, mqretError, datalen)
 
 	return jmsErr
 

--- a/mqjms/ContextImpl.go
+++ b/mqjms/ContextImpl.go
@@ -21,12 +21,13 @@ import (
 // ContextImpl encapsulates the objects necessary to maintain an active
 // connection to an IBM MQ queue manager.
 type ContextImpl struct {
-	qMgr              ibmmq.MQQueueManager
-	ctxLock           *sync.Mutex // Mutex to synchronize MQRC calls to the queue manager
-	sessionMode       int
-	receiveBufferSize int
-	sendCheckCount    int
-	sendCheckCountInc *int // Internal counter to keep track of async-put messages sent
+	qMgr                   ibmmq.MQQueueManager
+	ctxLock                *sync.Mutex // Mutex to synchronize MQRC calls to the queue manager
+	sessionMode            int
+	acceptTruncatedMessage bool
+	receiveBufferSize      int
+	sendCheckCount         int
+	sendCheckCountInc      *int // Internal counter to keep track of async-put messages sent
 }
 
 // CreateQueue implements the logic necessary to create a provider-specific


### PR DESCRIPTION
1. Return actual message length as an attribute of JMSExceptionImpl so that the application can know how large the readBufferSize needs to be in order to successfully consume it
2. Add support for AcceptTruncatedMessage for those applications that want to destructively read the message while only receiving the first portion of the message body that fits into the readBufferSize that has been set (the remaining content of the message body is discarded)